### PR TITLE
Reduce variability between compile outputs and transfertuning requests

### DIFF
--- a/llvm/driver/analysis.cpp
+++ b/llvm/driver/analysis.cpp
@@ -12,9 +12,11 @@
 
 #include "docc/cmd_args.h"
 #include "docc/docc.h"
+#include "sdfg/visualizer/dot_visualizer.h"
 
 llvm::cl::opt<std::string> TASK(llvm::cl::Positional, llvm::cl::desc("cfg | list"), llvm::cl::init(""));
 llvm::cl::opt<std::string> FILTER("filter", llvm::cl::desc("Regex to filter modules"), llvm::cl::init(""));
+llvm::cl::opt<std::string> SDFG_FILE("sdfg", llvm::cl::desc("SDFG file to analyze"), llvm::cl::init(""));
 
 int main(int argc, char** argv) {
     llvm::cl::ParseCommandLineOptions(argc, argv);
@@ -23,7 +25,32 @@ int main(int argc, char** argv) {
 
     docc::analysis::AnalysisManager analysis_manager;
 
-    if (TASK == "cfg") {
+    if (TASK == "dot") {
+        std::filesystem::path file = SDFG_FILE.getValue();
+        std::cout << "Generating Dot Graph from " << file << std::endl;
+
+        if (!std::filesystem::exists(file)) {
+            std::cerr << "File " << file << " does not exist!" << std::endl;
+            return 1;
+        }
+
+        if (file.extension() == ".json") {
+            auto dir = file.parent_path();
+            std::string basename = file.stem().string();
+
+            std::ifstream stream(file);
+            if (!stream.good()) {
+                throw std::runtime_error("Failed to open json");
+            }
+            nlohmann::json json = nlohmann::json::parse(stream);
+            sdfg::serializer::JSONSerializer js;
+            auto sdfg = js.deserialize(json);
+            sdfg::visualizer::DotVisualizer::writeToFile(*sdfg, dir / (basename + ".sdfg.dot"));
+        } else {
+            std::cerr << "File " << file << " is not a json file!" << std::endl;
+            return 1;
+        }
+    } else if (TASK == "cfg") {
         std::cout << "Generating Global CFG..." << std::endl;
 
         auto& glob = analysis_manager.get<docc::analysis::GlobalCFGAnalysis>();

--- a/llvm/include/docc/docc.h
+++ b/llvm/include/docc/docc.h
@@ -6,6 +6,6 @@ namespace docc {
 
 extern docc::PluginRegistry plugin_registry;
 
-void register_sdfg_dispatchers();
+std::shared_ptr<sdfg::plugins::Context> register_sdfg_dispatchers();
 
 } // namespace docc

--- a/llvm/include/docc/lifting/function_to_sdfg.h
+++ b/llvm/include/docc/lifting/function_to_sdfg.h
@@ -29,6 +29,8 @@ private:
     // Single region
     std::pair<bool, llvm::Value*> can_be_applied(llvm::Region& region);
 
+    void register_output_dir(sdfg::StructuredSDFG& sdfg);
+
     // Entire function
     std::unique_ptr<sdfg::StructuredSDFG> apply();
 

--- a/llvm/include/docc/passes/dumps/opt_report_pass.h
+++ b/llvm/include/docc/passes/dumps/opt_report_pass.h
@@ -12,10 +12,9 @@ namespace passes {
 
 class OPTReportPass : public llvm::PassInfoMixin<OPTReportPass> {
 private:
-    std::shared_ptr<docc::passes::PassReportCollector> report_;
 
 public:
-    explicit OPTReportPass(std::shared_ptr<docc::passes::PassReportCollector> report) : report_(std::move(report)) {}
+    explicit OPTReportPass() {}
 
     static bool available(analysis::AnalysisManager &AM) { return true; }
 

--- a/llvm/include/docc/passes/dumps/pass_report_collector.h
+++ b/llvm/include/docc/passes/dumps/pass_report_collector.h
@@ -1,8 +1,13 @@
 #pragma once
 
 #include <iostream>
+#include <memory>
+#include <mutex>
 #include <string>
+#include <unordered_map>
 
+#include <llvm/IR/Module.h>
+#include "docc/analysis/analysis.h"
 #include "sdfg/optimization_report/optimization_report.h"
 #include "sdfg/optimization_report/pass_report_consumer.h"
 #include "sdfg/structured_control_flow/control_flow_node.h"
@@ -39,6 +44,37 @@ public:
     void target_transform_possible(const std::string basicString, bool b) override;
 
     std::unordered_map<int32_t, std::unique_ptr<RegionReport>>* get_scope_reports(sdfg::StructuredSDFG* scope) const;
+};
+
+class PassReportManager : public docc::analysis::Analysis {
+private:
+    std::mutex mutex_;
+    std::unordered_map<std::string, std::unique_ptr<PassReportCollector>> collectors_;
+
+protected:
+    void run(docc::analysis::AnalysisManager& AM) override {}
+
+public:
+    PassReportCollector& get_collector(const llvm::Module& module) {
+        auto module_name = module.getName().str();
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = collectors_.find(module_name);
+        if (it == collectors_.end()) {
+            it = collectors_.emplace(module_name, std::make_unique<PassReportCollector>()).first;
+        }
+        return *it->second;
+    }
+
+    PassReportCollector* get_collector_if_exists(const llvm::Module& module) {
+        auto module_name = module.getName().str();
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = collectors_.find(module_name);
+        if (it == collectors_.end()) {
+            return nullptr;
+        } else {
+            return it->second.get();
+        }
+    }
 };
 
 } // namespace docc::passes

--- a/llvm/include/docc/passes/scheduling/scheduling_pass.h
+++ b/llvm/include/docc/passes/scheduling/scheduling_pass.h
@@ -12,19 +12,19 @@ namespace passes {
 
 class SchedulingPass : public llvm::PassInfoMixin<SchedulingPass> {
 private:
-    const sdfg::passes::scheduler::SchedulerRegistry &scheduler_registry_;
+    std::shared_ptr<sdfg::plugins::Context> context_;
+    target::TargetOptions target_options_;
     const bool dump_visualization_;
     const bool force_synchronous_;
     bool transfer_opt_;
-    sdfg::PassReportConsumer *const report_ = nullptr;
 
 public:
     SchedulingPass(
-        const sdfg::passes::scheduler::SchedulerRegistry &scheduler_registry,
+        std::shared_ptr<sdfg::plugins::Context> context,
+        const target::TargetOptions &target_options,
         bool force_synchronous = false,
         bool dump_visualization = false,
-        bool transfer_opt = true,
-        sdfg::PassReportConsumer *report = nullptr
+        bool transfer_opt = true
     );
 
     static bool available(analysis::AnalysisManager &AM) { return true; }

--- a/llvm/integration/polybench_openmp_test.py
+++ b/llvm/integration/polybench_openmp_test.py
@@ -111,7 +111,8 @@ def test_correlation(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         verification={
             "sdfgs": 8,
             "REDUCE": 4,
-            "SEQUENTIAL": 13,
+            "SEQUENTIAL": 5,
+            "VECTORIZE": 8,
             "MAP": 15,
             "CPU_PARALLEL": 10,
             "FOR": 4,
@@ -166,7 +167,8 @@ def test_covariance(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
             "MAP": 11,
             "CPU_PARALLEL": 7,
             "FOR": 4,
-            "SEQUENTIAL": 11,
+            "SEQUENTIAL": 4,
+            "VECTORIZE": 7,
             "REDUCE": 3,
         },
     )
@@ -225,7 +227,8 @@ def test_gemm(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
             "CPU_PARALLEL": 4,
             "GEMM": 1,
             "FOR": 2,
-            "SEQUENTIAL": 5,
+            "SEQUENTIAL": 2,
+            "VECTORIZE": 3,
             "REDUCE": 3,
         },
     )
@@ -282,7 +285,8 @@ def test_gemver(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         verification={
             "sdfgs": 8,
             "REDUCE": 4,
-            "SEQUENTIAL": 7,
+            "SEQUENTIAL": 2,
+            "VECTORIZE": 5,
             "MAP": 5,
             "CPU_PARALLEL": 4,
             "FOR": 2,
@@ -343,7 +347,8 @@ def test_gesummv(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
             "REDUCE": 4,
             "MAP": 4,
             "CPU_PARALLEL": 4,
-            "SEQUENTIAL": 5,
+            "SEQUENTIAL": 1,
+            "VECTORIZE": 4,
             "FOR": 1,
         },
     )
@@ -401,7 +406,8 @@ def test_symm(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
             "REDUCE": 4,
             "MAP": 6,
             "CPU_PARALLEL": 3,
-            "SEQUENTIAL": 10,
+            "SEQUENTIAL": 4,
+            "VECTORIZE": 6,
             "FOR": 3,
         },
     )
@@ -457,7 +463,8 @@ def test_syr2k(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         verification={
             "sdfgs": 8,
             "REDUCE": 4,
-            "SEQUENTIAL": 8,
+            "SEQUENTIAL": 3,
+            "VECTORIZE": 5,
             "MAP": 6,
             "CPU_PARALLEL": 4,
             "FOR": 2,
@@ -515,7 +522,8 @@ def test_syrk(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         verification={
             "sdfgs": 8,
             "REDUCE": 4,
-            "SEQUENTIAL": 8,
+            "SEQUENTIAL": 3,
+            "VECTORIZE": 5,
             "MAP": 6,
             "CPU_PARALLEL": 4,
             "FOR": 2,
@@ -635,7 +643,8 @@ def test_2mm(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         verification={
             "sdfgs": 8,
             "REDUCE": 3,
-            "SEQUENTIAL": 5,
+            "SEQUENTIAL": 2,
+            "VECTORIZE": 3,
             "MAP": 6,
             "CPU_PARALLEL": 6,
             "GEMM": 2,
@@ -695,7 +704,8 @@ def test_3mm(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         verification={
             "sdfgs": 8,
             "REDUCE": 3,
-            "SEQUENTIAL": 5,
+            "SEQUENTIAL": 2,
+            "VECTORIZE": 3,
             "MAP": 7,
             "CPU_PARALLEL": 7,
             "GEMM": 3,
@@ -757,7 +767,8 @@ def test_atax(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
             "REDUCE": 4,
             "MAP": 6,
             "CPU_PARALLEL": 5,
-            "SEQUENTIAL": 7,
+            "SEQUENTIAL": 2,
+            "VECTORIZE": 5,
             "FOR": 2,
         },
     )
@@ -875,7 +886,8 @@ def test_doitgen(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         verification={
             "sdfgs": 9,
             "REDUCE": 3,
-            "SEQUENTIAL": 18,
+            "SEQUENTIAL": 9,
+            "VECTORIZE": 9,
             "CPU_PARALLEL": 2,
             "FOR": 9,
             "MAP": 8,
@@ -935,7 +947,8 @@ def test_mvt(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
             "REDUCE": 4,
             "MAP": 3,
             "CPU_PARALLEL": 2,
-            "SEQUENTIAL": 8,
+            "SEQUENTIAL": 3,
+            "VECTORIZE": 5,
             "FOR": 3,
         },
     )
@@ -991,7 +1004,8 @@ def test_cholesky(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         verification={
             "sdfgs": 8,
             "REDUCE": 6,
-            "SEQUENTIAL": 12,
+            "SEQUENTIAL": 4,
+            "VECTORIZE": 8,
             "MAP": 8,
             "CPU_PARALLEL": 6,
             "FOR": 4,
@@ -1052,7 +1066,8 @@ def test_durbin(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
             "MAP": 3,
             "CPU_PARALLEL": 3,
             "FOR": 2,
-            "SEQUENTIAL": 6,
+            "SEQUENTIAL": 2,
+            "VECTORIZE": 4,
         },
     )
     test_case = benchmark_path / "durbin.c"
@@ -1078,6 +1093,7 @@ def test_durbin(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         [Path(__file__).parent / "tests" / "polybench" / "utilities" / "polybench.c"],
         partial(
             verify,
+            max_ulps=1e8,
             dtype=np.float64 if datatype == "-DDATA_TYPE_IS_DOUBLE" else np.float32,
         ),
         sdfg_verification=verifier,
@@ -1107,7 +1123,8 @@ def test_gramschmidt(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         verification={
             "sdfgs": 8,
             "REDUCE": 4,
-            "SEQUENTIAL": 11,
+            "SEQUENTIAL": 6,
+            "VECTORIZE": 5,
             "MAP": 6,
             "CPU_PARALLEL": 5,
             "FOR": 6,
@@ -1136,6 +1153,7 @@ def test_gramschmidt(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         [Path(__file__).parent / "tests" / "polybench" / "utilities" / "polybench.c"],
         partial(
             verify,
+            max_ulps=1e8,
             dtype=np.float64 if datatype == "-DDATA_TYPE_IS_DOUBLE" else np.float32,
         ),
         sdfg_verification=verifier,
@@ -1165,7 +1183,8 @@ def test_lu(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         verification={
             "sdfgs": 8,
             "REDUCE": 6,
-            "SEQUENTIAL": 13,
+            "SEQUENTIAL": 5,
+            "VECTORIZE": 8,
             "MAP": 9,
             "CPU_PARALLEL": 6,
             "FOR": 4,
@@ -1223,7 +1242,8 @@ def test_ludcmp(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         verification={
             "sdfgs": 8,
             "REDUCE": 8,
-            "SEQUENTIAL": 16,
+            "SEQUENTIAL": 6,
+            "VECTORIZE": 10,
             "MAP": 10,
             "CPU_PARALLEL": 7,
             "FOR": 5,
@@ -1252,6 +1272,7 @@ def test_ludcmp(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         [Path(__file__).parent / "tests" / "polybench" / "utilities" / "polybench.c"],
         partial(
             verify,
+            max_ulps=1e8,
             dtype=np.float64 if datatype == "-DDATA_TYPE_IS_DOUBLE" else np.float32,
         ),
         sdfg_verification=verifier,
@@ -1338,7 +1359,8 @@ def test_deriche(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         verification={
             "sdfgs": 8,
             "REDUCE": 3,
-            "SEQUENTIAL": 9,
+            "SEQUENTIAL": 6,
+            "VECTORIZE": 3,
             "MAP": 7,
             "CPU_PARALLEL": 7,
             "FOR": 6,
@@ -1386,7 +1408,8 @@ def test_floyd_warshall(compiler="clang-19", size="MEDIUM_DATASET"):
             "MAP": 1,
             "CPU_PARALLEL": 1,
             "FOR": 5,
-            "SEQUENTIAL": 8,
+            "SEQUENTIAL": 5,
+            "VECTORIZE": 3,
             "REDUCE": 3,
         },
     )
@@ -1429,7 +1452,8 @@ def test_nussinov(compiler="clang-19", size="MEDIUM_DATASET"):
             "MAP": 2,
             "CPU_PARALLEL": 2,
             "FOR": 4,
-            "SEQUENTIAL": 7,
+            "SEQUENTIAL": 4,
+            "VECTORIZE": 3,
             "WHILE": 1,
             "REDUCE": 3,
         },
@@ -1476,7 +1500,8 @@ def test_adi(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         verification={
             "sdfgs": 8,
             "REDUCE": 3,
-            "SEQUENTIAL": 10,
+            "SEQUENTIAL": 7,
+            "VECTORIZE": 3,
             "MAP": 9,
             "CPU_PARALLEL": 9,
             "FOR": 7,
@@ -1529,7 +1554,8 @@ def test_fdtd_2d(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         verification={
             "sdfgs": 8,
             "REDUCE": 3,
-            "SEQUENTIAL": 10,
+            "SEQUENTIAL": 7,
+            "VECTORIZE": 3,
             "MAP": 6,
             "CPU_PARALLEL": 6,
             "FOR": 7,
@@ -1582,7 +1608,8 @@ def test_heat_3d(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
         verification={
             "sdfgs": 8,
             "REDUCE": 3,
-            "SEQUENTIAL": 7,
+            "SEQUENTIAL": 4,
+            "VECTORIZE": 3,
             "MAP": 3,
             "CPU_PARALLEL": 3,
             "FOR": 4,
@@ -1637,7 +1664,8 @@ def test_jacobi_1d(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
             "MAP": 3,
             "CPU_PARALLEL": 3,
             "FOR": 2,
-            "SEQUENTIAL": 5,
+            "SEQUENTIAL": 2,
+            "VECTORIZE": 3,
             "REDUCE": 3,
         },
     )
@@ -1690,7 +1718,8 @@ def test_jacobi_2d(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
             "MAP": 3,
             "CPU_PARALLEL": 3,
             "FOR": 3,
-            "SEQUENTIAL": 6,
+            "SEQUENTIAL": 3,
+            "VECTORIZE": 3,
             "REDUCE": 3,
         },
     )
@@ -1743,7 +1772,8 @@ def test_seidel_2d(datatype, compiler="clang-19", size="MEDIUM_DATASET"):
             "MAP": 1,
             "CPU_PARALLEL": 1,
             "FOR": 5,
-            "SEQUENTIAL": 8,
+            "SEQUENTIAL": 5,
+            "VECTORIZE": 3,
             "REDUCE": 3,
         },
     )

--- a/llvm/integration/test_runner.py
+++ b/llvm/integration/test_runner.py
@@ -4,13 +4,14 @@ import subprocess
 from typing import Dict
 from datetime import datetime
 from pathlib import Path
-from tempfile import mkdtemp 
+from tempfile import mkdtemp
 import threading
+
 
 class SDFGVerification:
     def __init__(self, verification: dict):
         self._verification = verification
-    
+
     def _parse_opt_report(self, output_str: str) -> Dict[str, int]:
         opt_mode = False
         stats = {}
@@ -37,8 +38,11 @@ class SDFGVerification:
             if key not in stats:
                 assert val == 0, f"Key {key} not found in stats"
             else:
-                assert stats[key] == val, f"Key {key} has value {stats[key]} but expected {val}"
+                assert (
+                    stats[key] == val
+                ), f"Key {key} has value {stats[key]} but expected {val}"
         print("All verifications passed.")
+
 
 class TransformationVerification:
     def __init__(self, transformations: dict):
@@ -46,34 +50,43 @@ class TransformationVerification:
 
     def verify(self, output_dir, stderr: str = None) -> None:
         import json
+
         opt_report_files = list(Path(output_dir).rglob("sdfg_0.opt_report.json"))
         if not opt_report_files:
             raise FileNotFoundError(f"No sdfg_0.opt_report.json found in {output_dir}")
         for opt_report_path in opt_report_files:
             print(f"Using opt_report file at: {opt_report_path}")
             # Load the opt_report JSON file
-            with open(opt_report_path, 'r') as f:
+            with open(opt_report_path, "r") as f:
                 opt_report = json.load(f)
             regions = opt_report.get("regions", [])
             if regions != []:
                 break
 
         # Build a lookup: loopnest_index -> region
-        loopnest_to_region = {region.get("loopnest_index"): region for region in regions}
+        loopnest_to_region = {
+            region.get("loopnest_index"): region for region in regions
+        }
 
         for transformation, params in self._transformations.items():
             # Check for new dict format with 'loop_nests' and 'max_tuned_loops'
-            if isinstance(params, dict) and 'loop_nests' in params and 'tuned_loops' in params:
-                loop_nests = params['loop_nests']
-                tuned_loops = params['tuned_loops']
+            if (
+                isinstance(params, dict)
+                and "loop_nests" in params
+                and "tuned_loops" in params
+            ):
+                loop_nests = params["loop_nests"]
+                tuned_loops = params["tuned_loops"]
                 # Check that transformation is present in all specified loop_nests
                 for idx in loop_nests:
                     region = loopnest_to_region.get(idx)
-                    assert region is not None, f"Region with loopnest_index {idx} not found."
+                    assert (
+                        region is not None
+                    ), f"Region with loopnest_index {idx} not found."
                     transformations = region.get("transformations", {})
-                    assert transformation in transformations, (
-                        f"Transformation {transformation} not found in region with loopnest_index {idx}."
-                    )
+                    assert (
+                        transformation in transformations
+                    ), f"Transformation {transformation} not found in region with loopnest_index {idx}."
                 # Count total number of times transformation was applied
                 applied_count = 0
                 for region in regions:
@@ -81,42 +94,46 @@ class TransformationVerification:
                     if transformation in transformations:
                         # Check if 'applied' is True (if present)
                         t = transformations[transformation]
-                        if isinstance(t, dict) and t.get('applied', True):
+                        if isinstance(t, dict) and t.get("applied", True):
                             applied_count += 1
                         elif t is True:
                             applied_count += 1
-                assert applied_count == tuned_loops, (
-                    f"Transformation {transformation} applied {applied_count} times but expected {tuned_loops} times"
-                )
+                assert (
+                    applied_count == tuned_loops
+                ), f"Transformation {transformation} applied {applied_count} times but expected {tuned_loops} times"
             else:
                 # Fallback to old behavior: params is a set of indices
                 for idx in params:
                     region = loopnest_to_region.get(idx)
-                    assert region is not None, f"Region with loopnest_index {idx} not found."
+                    assert (
+                        region is not None
+                    ), f"Region with loopnest_index {idx} not found."
                     transformations = region.get("transformations", {})
-                    assert transformation in transformations, (
-                        f"Transformation {transformation} not found in region with loopnest_index {idx}."
-                    )
+                    assert (
+                        transformation in transformations
+                    ), f"Transformation {transformation} not found in region with loopnest_index {idx}."
+
     print("All transformation verifications passed.")
+
 
 class TestRunner:
     __test__ = False
 
     def __init__(
-            self,
-            test_suite,
-            test_case,
-            compiler,
-            reference_compiler,
-            flags,
-            mode,
-            additional_source_files,
-            evaluation_function,
-            sdfg_verification : SDFGVerification = None,
-            transformation_verification : TransformationVerification = None,
-            docc_flags: list = [],
-            output_dir = None
-        ) -> None:
+        self,
+        test_suite,
+        test_case,
+        compiler,
+        reference_compiler,
+        flags,
+        mode,
+        additional_source_files,
+        evaluation_function,
+        sdfg_verification: SDFGVerification = None,
+        transformation_verification: TransformationVerification = None,
+        docc_flags: list = [],
+        output_dir=None,
+    ) -> None:
         self._test_suite = test_suite
         self._test_case = test_case
         self._compiler = compiler
@@ -129,15 +146,18 @@ class TestRunner:
         self._transformation_verification = transformation_verification
         self._docc_flags = docc_flags
         if output_dir is None:
-            rootDir = Path(__file__).parent / "pytestOut" / (test_suite+"-"+mode)
+            rootDir = Path(__file__).parent / "pytestOut" / (test_suite + "-" + mode)
         else:
             rootDir = Path(output_dir)
         out_dir = rootDir / test_case.name
         Path.mkdir(out_dir, parents=True, exist_ok=True)
-        self.output_dir_ = Path(mkdtemp(prefix=datetime.now().strftime('%Y-%m-%d_%H-%M-%S_'), dir= out_dir))
+        self.output_dir_ = Path(
+            mkdtemp(prefix=datetime.now().strftime("%Y-%m-%d_%H-%M-%S_"), dir=out_dir)
+        )
 
     def run(self, timeout=600) -> None:
         exception_bucket = []
+
         def target():
             try:
                 reference_file = self._compile(self._test_case, reference=True)
@@ -157,7 +177,7 @@ class TestRunner:
 
         if t.is_alive():
             raise TimeoutError("Timeout reached")
-        
+
         return
 
     def _compile(self, test_case, reference: bool) -> None:
@@ -190,7 +210,12 @@ class TestRunner:
 
         output_file = output_path / "a.out"
         cmd += ["-o", str(output_file.absolute())]
-        print("\nBuild command for", "reference" if reference else "test", "executable:\n", " ".join(cmd))
+        print(
+            "\nBuild command for",
+            "reference" if reference else "test",
+            "executable:\n",
+            " ".join(cmd),
+        )
 
         Path.mkdir(output_path, exist_ok=False)
         my_env = os.environ.copy()
@@ -208,10 +233,10 @@ class TestRunner:
         print(stdout)
         print(stderr)
 
-        if not reference and self._sdfg_verification is not None:
-            self._sdfg_verification.verify(stderr)
-
         if not reference and self._transformation_verification is not None:
             self._transformation_verification.verify(self.output_dir_, stderr)
+
+        if not reference and self._sdfg_verification is not None:
+            self._sdfg_verification.verify(stderr)
 
         return output_file

--- a/llvm/src/docc.cpp
+++ b/llvm/src/docc.cpp
@@ -11,6 +11,10 @@
 #include <sdfg/targets/cuda/plugin.h>
 #include <sdfg/targets/memory/plugin.h>
 #include <sdfg/targets/omp/plugin.h>
+#include <sdfg/targets/vectorize/plugin.h>
+
+#include "docc/target/docc_target.h"
+#include "docc/target/tenstorrent/target.h"
 #ifdef DOCC_BUILD_TARGET_TENSTORRENT
 #include <docc/target/tenstorrent/plugin.h>
 #endif
@@ -32,20 +36,22 @@ docc::PluginRegistry plugin_registry;
 
 static std::once_flag dispatcher_registration_flag;
 
-void register_sdfg_dispatchers() {
+std::shared_ptr<sdfg::plugins::Context> register_sdfg_dispatchers() {
+    static std::shared_ptr<sdfg::plugins::Context> context = sdfg::plugins::Context::global_context_ptr();
+
     std::call_once(dispatcher_registration_flag, []() {
         sdfg::codegen::register_default_dispatchers();
         sdfg::serializer::register_default_serializers();
 
-        sdfg::omp::register_omp_plugin();
-        sdfg::cuda::register_cuda_plugin();
-        sdfg::rocm::register_rocm_plugin();
+        sdfg::omp::register_omp_plugin(*context);
+        sdfg::vectorize::register_vectorize_plugin(*context);
+        sdfg::cuda::register_cuda_plugin(*context);
+        sdfg::rocm::register_rocm_plugin(*context);
+        docc::target::register_builtin_targets(*context); // for cuda, rocm, sequential, openmp targets via DoccTargets
 #ifdef DOCC_BUILD_TARGET_TENSTORRENT
-        sdfg::tenstorrent::register_tenstorrent_plugin();
+        docc::target::tenstorrent::register_plugin(*context);
 #endif
         sdfg::offloading::register_external_data_transfers_plugin();
-
-        sdfg::plugins::Context context = sdfg::plugins::Context::global_context();
 
         if (!DOCC_Plugins.empty()) {
             std::stringstream ss(DOCC_Plugins);
@@ -68,7 +74,7 @@ void register_sdfg_dispatchers() {
                     LLVM_DEBUG_PRINTLN("[docc] Plugin " << plugin << " does not have a register callback");
                     exit(EXIT_FAILURE);
                 }
-                p.register_plugin_callback(context);
+                p.register_plugin_callback(*context);
                 if (!p.sdfg_lookup) {
                     LLVM_DEBUG_PRINTLN("[docc] Plugin " << plugin << " does not have an sdfg lookup function");
                     exit(EXIT_FAILURE);
@@ -78,6 +84,8 @@ void register_sdfg_dispatchers() {
             }
         }
     });
+
+    return context;
 }
 
 } // namespace docc

--- a/llvm/src/lifting/function_to_sdfg.cpp
+++ b/llvm/src/lifting/function_to_sdfg.cpp
@@ -346,6 +346,11 @@ std::pair<bool, llvm::Value*> FunctionToSDFG::can_be_applied(llvm::Region& regio
     return {true, nullptr};
 }
 
+void FunctionToSDFG::register_output_dir(sdfg::StructuredSDFG& sdfg) {
+    auto out_dir = analysis::SDFGRegistry::docc_extract_dir(*function_.getParent());
+    sdfg.add_metadata("output_dir", out_dir.string());
+}
+
 std::pair<bool, llvm::Value*> FunctionToSDFG::can_be_applied() {
     auto& TLI = this->FAM_.getResult<llvm::TargetLibraryAnalysis>(this->function_);
 
@@ -567,6 +572,8 @@ std::unique_ptr<sdfg::StructuredSDFG> FunctionToSDFG::apply(llvm::Region& region
     LiftingReport::add_successful_lift(::docc::utils::get_debug_info(*external_function));
     auto structured_sdfg = structured_builder.move();
 
+    register_output_dir(*structured_sdfg);
+
     // Simplify SDFG
     auto simplified_sdfg = this->simplify(structured_sdfg);
 
@@ -614,6 +621,8 @@ std::unique_ptr<sdfg::StructuredSDFG> FunctionToSDFG::apply() {
 
     LiftingReport::add_successful_lift(::docc::utils::get_debug_info(this->function_));
     auto structured_sdfg = structured_builder.move();
+
+    register_output_dir(*structured_sdfg);
 
     // Simplify SDFG
     auto simplified_sdfg = this->simplify(structured_sdfg);

--- a/llvm/src/passes/dumps/opt_report_pass.cpp
+++ b/llvm/src/passes/dumps/opt_report_pass.cpp
@@ -17,6 +17,12 @@ namespace passes {
 
 llvm::PreservedAnalyses OPTReportPass::
     run(llvm::Module& Module, llvm::ModuleAnalysisManager& MAM, analysis::AnalysisManager& AM) {
+    auto report_ = AM.get<docc::passes::PassReportManager>().get_collector_if_exists(Module);
+
+    if (!report_) {
+        return llvm::PreservedAnalyses::all();
+    }
+
     auto& registry = AM.get<analysis::SDFGRegistry>();
     if (!registry.has_module(Module)) {
         return llvm::PreservedAnalyses::all();

--- a/llvm/src/passes/scheduling/scheduling_pass.cpp
+++ b/llvm/src/passes/scheduling/scheduling_pass.cpp
@@ -2,51 +2,68 @@
 
 #include "docc/analysis/sdfg_registry.h"
 #include "docc/cmd_args.h"
+#include "docc/passes/dumps/pass_report_collector.h"
+#include "sdfg/passes/rpc/daisytuner_rpc_context.h"
+#include "sdfg/passes/rpc/rpc_scheduler.h"
 #include "sdfg/passes/scheduler/loop_scheduling_pass.h"
 
 namespace docc {
 namespace passes {
 
 SchedulingPass::SchedulingPass(
-    const sdfg::passes::scheduler::SchedulerRegistry& scheduler_registry,
+    std::shared_ptr<sdfg::plugins::Context> context,
+    const target::TargetOptions& target_options,
     bool force_synchronous,
     bool dump_visualization,
-    bool transfer_opt,
-    sdfg::PassReportConsumer* report
+    bool transfer_opt
 )
-    : scheduler_registry_(scheduler_registry),
+    : context_(std::move(context)), target_options_(target_options),
       force_synchronous_(force_synchronous || DOCC_FORCE_SYNCHRONOUS_OFFLOADING),
-      dump_visualization_(dump_visualization), transfer_opt_(transfer_opt), report_(report) {}
+      dump_visualization_(dump_visualization), transfer_opt_(transfer_opt) {}
 
 llvm::PreservedAnalyses SchedulingPass::
     run(llvm::Module& Module, llvm::ModuleAnalysisManager& MAM, analysis::AnalysisManager& AM) {
+    auto& report_collector = AM.get<docc::passes::PassReportManager>().get_collector(Module);
+
     auto& registry = AM.get<analysis::SDFGRegistry>();
     if (!registry.has_module(Module)) {
         return llvm::PreservedAnalyses::all();
     }
 
-    auto target = docc::DOCC_TUNE.getValue();
-    auto remote_tuning = docc::DOCC_TRANSFERTUNE.getValue();
     auto offload_unknown_sizes = docc::DOCC_OFFLOAD_UNKNOWN_SIZES.getValue();
 
-    std::vector<sdfg::passes::scheduler::LoopScheduler*> schedulers;
-    if (target != "tenstorrent" && remote_tuning) {
-        schedulers.push_back(scheduler_registry_.get_loop_scheduler("rpc"));
+    std::unique_ptr<sdfg::passes::rpc::RPCScheduler> rpc;
+
+    std::vector<std::shared_ptr<sdfg::passes::scheduler::LoopScheduler>> schedulers;
+    if (target_options_.remote_tuning) {
+        std::shared_ptr<sdfg::passes::rpc::RpcContext> rpc_ctx =
+            sdfg::passes::rpc::DaisytunerRpcContext::from_docc_config();
+        rpc = std::make_unique<sdfg::passes::rpc::RPCScheduler>(
+            rpc_ctx, target_options_.target, target_options_.category, dump_visualization_
+        );
+        schedulers.push_back(std::move(rpc));
     }
-    if (target != "sequential") {
-        schedulers.push_back(scheduler_registry_.get_loop_scheduler(target));
+
+    auto docc_target = context_->get_target_handler(target_options_.target);
+    if (docc_target) {
+        auto target_schedulers = docc_target->safe_get_target_loop_schedulers(target_options_);
+        if (!target_schedulers.empty()) {
+            schedulers.insert(schedulers.end(), target_schedulers.begin(), target_schedulers.end());
+        }
     }
+
 
     registry.for_each_sdfg_modifiable(Module, [&](analysis::SDFGHolder&, sdfg::StructuredSDFG& sdfg) {
         sdfg::builder::StructuredSDFGBuilder builder(sdfg);
         sdfg::analysis::AnalysisManager analysis_manager(builder.subject());
-        if (report_) report_->in_scope(&builder.subject());
+        report_collector.in_scope(&builder.subject());
 
-        sdfg::passes::scheduler::LoopSchedulingPass loop_scheduling_pass(schedulers, report_, offload_unknown_sizes);
+        sdfg::passes::scheduler::LoopSchedulingPass
+            loop_scheduling_pass(schedulers, &report_collector, offload_unknown_sizes);
         loop_scheduling_pass.run(builder, analysis_manager);
     });
 
-    if (report_) report_->no_scope();
+    report_collector.no_scope();
     return llvm::PreservedAnalyses::all();
 }
 

--- a/llvm/src/plugin.cpp
+++ b/llvm/src/plugin.cpp
@@ -77,24 +77,17 @@ extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo llvmGetPassPluginIn
         .PluginVersion = "v0.0.1",
         .RegisterPassBuilderCallbacks =
             [](llvm::PassBuilder &PB) {
-                docc::register_sdfg_dispatchers();
+                auto context = docc::register_sdfg_dispatchers();
 
                 auto target = docc::DOCC_TUNE.getValue();
                 auto category = docc::DOCC_TRANSFERTUNE_CATEGORY.getValue();
 
                 auto remote_tuning = docc::DOCC_TRANSFERTUNE.getValue();
 
-                auto &sched_registry = sdfg::passes::scheduler::SchedulerRegistry::instance();
-
-                if (remote_tuning) {
-                    std::shared_ptr<sdfg::passes::rpc::RpcContext> context =
-                        sdfg::passes::rpc::DaisytunerRpcContext::from_docc_config();
-                    sdfg::passes::rpc::register_rpc_loop_opt(context, target, category);
-                    // TODO don't use global state here
-                }
+                docc::target::TargetOptions target_options(target, category, remote_tuning);
 
                 // Compile-Time Pass Registration
-                PB.registerPipelineStartEPCallback([&sched_registry](
+                PB.registerPipelineStartEPCallback([context, target_options](
                                                        llvm::ModulePassManager &MPM, llvm::OptimizationLevel Level
                                                    ) {
                     // Simplification
@@ -184,10 +177,7 @@ extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo llvmGetPassPluginIn
                         MPM.addPass(llvm::createModuleToFunctionPassAdaptor(std::move(FPM)));
                     }
 
-                    std::shared_ptr<docc::passes::PassReportCollector> report_consumer;
                     bool generate_opt_report_file = true;
-
-                    report_consumer = std::make_shared<docc::passes::PassReportCollector>();
 
                     // Lift SDFGs from functions
                     MPM.addPass(docc::passes::createDOCCPass(docc::passes::FunctionToSDFGPass(docc::plugin_registry), AM)
@@ -209,17 +199,16 @@ extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo llvmGetPassPluginIn
                     if (docc::DOCC_TUNE != "none") {
                         // Dump sdfg and features after all seuquential optimizations are done but
                         // before offloading
-                        MPM.addPass(docc::passes::createDOCCPass(docc::passes::DumpSDFGPass(), AM));
+                        MPM.addPass(docc::passes::createDOCCPass(docc::passes::DumpSDFGPass("", true), AM));
                         MPM.addPass(docc::passes::createDOCCPass(
-                            docc::passes::SchedulingPass(
-                                sched_registry, false, false, enable_offloading_transfer_opt, report_consumer.get()
-                            ),
+                            docc::passes::
+                                SchedulingPass(context, target_options, false, false, enable_offloading_transfer_opt),
                             AM
                         ));
                     }
 
                     if (generate_opt_report_file) {
-                        MPM.addPass(docc::passes::createDOCCPass(docc::passes::OPTReportPass(report_consumer), AM));
+                        MPM.addPass(docc::passes::createDOCCPass(docc::passes::OPTReportPass(), AM));
                     }
 
                     MPM.addPass(docc::passes::createDOCCPass(

--- a/opt/include/sdfg/passes/scheduler/loop_scheduling_pass.h
+++ b/opt/include/sdfg/passes/scheduler/loop_scheduling_pass.h
@@ -16,7 +16,7 @@ namespace scheduler {
 
 class LoopSchedulingPass : public Pass {
 private:
-    std::vector<LoopScheduler*> targets_;
+    std::vector<std::shared_ptr<LoopScheduler>> targets_;
     sdfg::PassReportConsumer* report_;
     bool offload_unknown_sizes_;
     sdfg::transformations::Recorder* recorder_ = nullptr;
@@ -27,7 +27,9 @@ private:
 
 public:
     LoopSchedulingPass(
-        const std::vector<LoopScheduler*>& targets, sdfg::PassReportConsumer* report, bool offload_unknown_sizes = false
+        const std::vector<std::shared_ptr<LoopScheduler>>& targets,
+        sdfg::PassReportConsumer* report,
+        bool offload_unknown_sizes = false
     )
         : targets_(targets), report_(report), offload_unknown_sizes_(offload_unknown_sizes) {}
     ~LoopSchedulingPass() override = default;

--- a/opt/include/sdfg/passes/scheduler/scheduler_registry.h
+++ b/opt/include/sdfg/passes/scheduler/scheduler_registry.h
@@ -13,7 +13,7 @@ namespace scheduler {
 class SchedulerRegistry {
 private:
     mutable std::mutex mutex_;
-    std::unordered_map<std::string, std::unique_ptr<LoopScheduler>> scheduler_map_;
+    std::unordered_map<std::string, std::shared_ptr<LoopScheduler>> scheduler_map_;
 
 public:
     static SchedulerRegistry& instance() {
@@ -27,20 +27,18 @@ public:
         if (scheduler_map_.find(target) != scheduler_map_.end()) {
             return;
         }
-        scheduler_map_[target] = std::make_unique<T>(std::forward<Args>(args)...);
+        scheduler_map_[target] = std::make_shared<T>(std::forward<Args>(args)...);
     }
-    LoopScheduler* get_loop_scheduler(std::string target) const {
+    std::shared_ptr<LoopScheduler> get_loop_scheduler(std::string target) const {
         auto it = scheduler_map_.find(target);
         if (it != scheduler_map_.end()) {
-            return it->second.get();
+            return it->second;
         }
         return nullptr;
     }
 
     size_t size_loop_schedulers() const { return scheduler_map_.size(); }
 };
-
-std::unique_ptr<LoopScheduler> create_loop_scheduler(const std::string target);
 
 } // namespace scheduler
 } // namespace passes

--- a/opt/include/sdfg/targets/omp/plugin.h
+++ b/opt/include/sdfg/targets/omp/plugin.h
@@ -11,8 +11,8 @@
 namespace sdfg {
 namespace omp {
 
-inline void register_omp_plugin() {
-    codegen::MapDispatcherRegistry::instance().register_map_dispatcher(
+inline void register_omp_plugin(sdfg::plugins::Context& context) {
+    context.get_map_dispatcher_registry().register_map_dispatcher(
         ScheduleType_OMP::value(),
         [](codegen::LanguageExtension& language_extension,
            StructuredSDFG& sdfg,
@@ -28,6 +28,11 @@ inline void register_omp_plugin() {
 
     passes::scheduler::SchedulerRegistry::instance()
         .register_loop_scheduler<passes::scheduler::OMPScheduler>(passes::scheduler::OMPScheduler::target());
+}
+
+inline void register_omp_plugin() {
+    auto ctx = plugins::Context::global_context();
+    register_omp_plugin(ctx);
 }
 
 } // namespace omp

--- a/opt/include/sdfg/targets/vectorize/plugin.h
+++ b/opt/include/sdfg/targets/vectorize/plugin.h
@@ -11,8 +11,8 @@
 namespace sdfg {
 namespace vectorize {
 
-inline void register_vectorize_plugin() {
-    codegen::MapDispatcherRegistry::instance().register_map_dispatcher(
+inline void register_vectorize_plugin(plugins::Context& context) {
+    context.get_map_dispatcher_registry().register_map_dispatcher(
         ScheduleType_Vectorize::value(),
         [](codegen::LanguageExtension& language_extension,
            StructuredSDFG& sdfg,
@@ -26,7 +26,7 @@ inline void register_vectorize_plugin() {
         }
     );
 
-    codegen::ReduceDispatcherRegistry::instance().register_reduce_dispatcher(
+    context.get_reduce_dispatcher_registry().register_reduce_dispatcher(
         ScheduleType_Vectorize::value(),
         [](codegen::LanguageExtension& language_extension,
            StructuredSDFG& sdfg,
@@ -40,9 +40,14 @@ inline void register_vectorize_plugin() {
         }
     );
 
-    passes::scheduler::SchedulerRegistry::instance()
+    context.get_scheduler_registry()
         .register_loop_scheduler<passes::scheduler::VectorizeScheduler>(passes::scheduler::VectorizeScheduler::target()
         );
+}
+
+inline void register_vectorize_plugin() {
+    auto ctx = sdfg::plugins::Context::global_context();
+    register_vectorize_plugin(ctx);
 }
 
 } // namespace vectorize

--- a/opt/src/passes/scheduler/scheduler_registry.cpp
+++ b/opt/src/passes/scheduler/scheduler_registry.cpp
@@ -4,18 +4,6 @@
 
 namespace sdfg {
 namespace passes {
-namespace scheduler {
-
-std::unique_ptr<LoopScheduler> create_loop_scheduler(const std::string target) {
-    auto scheduler = SchedulerRegistry::instance().get_loop_scheduler(target);
-    if (scheduler) {
-        return std::unique_ptr<LoopScheduler>(scheduler);
-    }
-
-    throw std::runtime_error("Unsupported scheduling target: " + target);
-};
-
-
-} // namespace scheduler
+namespace scheduler {} // namespace scheduler
 } // namespace passes
 } // namespace sdfg

--- a/opt/tests/passes/scheduler/cuda_scheduler_test.cpp
+++ b/opt/tests/passes/scheduler/cuda_scheduler_test.cpp
@@ -13,9 +13,10 @@
 
 using namespace sdfg;
 
-static passes::scheduler::CUDAScheduler* get_cuda_sched() {
-    static passes::scheduler::CUDAScheduler instance;
-    return &instance;
+static std::shared_ptr<passes::scheduler::CUDAScheduler> get_cuda_sched() {
+    static std::shared_ptr<passes::scheduler::CUDAScheduler> instance =
+        std::make_shared<passes::scheduler::CUDAScheduler>();
+    return instance;
 }
 
 TEST(CUDASchedulerTest, OuterParallelMapWithInnerMap) {

--- a/opt/tests/passes/scheduler/omp_scheduler_test.cpp
+++ b/opt/tests/passes/scheduler/omp_scheduler_test.cpp
@@ -8,9 +8,10 @@
 
 using namespace sdfg;
 
-static passes::scheduler::OMPScheduler* get_omp_sched() {
-    static passes::scheduler::OMPScheduler instance;
-    return &instance;
+static std::shared_ptr<passes::scheduler::OMPScheduler> get_omp_sched() {
+    static std::shared_ptr<passes::scheduler::OMPScheduler> instance =
+        std::make_shared<passes::scheduler::OMPScheduler>();
+    return instance;
 }
 
 TEST(OMPSchedulerTest, OuterParallelMapWithInnerMap) {

--- a/python/bindings/passes/py_passes.cpp
+++ b/python/bindings/passes/py_passes.cpp
@@ -72,14 +72,14 @@ void register_passes(py::module& m) {
     py::class_<scheduler::LoopSchedulingPass, Pass>(m, "LoopSchedulingPass")
         .def(
             py::init([](const std::vector<std::string>& targets, bool offload_unknown_sizes) {
-                std::vector<scheduler::LoopScheduler*> schedulers;
+                std::vector<std::shared_ptr<scheduler::LoopScheduler>> schedulers;
                 auto& registry = scheduler::SchedulerRegistry::instance();
                 for (const auto& target : targets) {
-                    auto* sched = registry.get_loop_scheduler(target);
+                    auto sched = registry.get_loop_scheduler(target);
                     if (!sched) {
                         throw std::runtime_error("No loop scheduler registered for target '" + target + "'");
                     }
-                    schedulers.push_back(sched);
+                    schedulers.push_back(std::move(sched));
                 }
 
                 return std::make_unique<scheduler::LoopSchedulingPass>(schedulers, nullptr, offload_unknown_sizes);

--- a/python/bindings/py_structured_sdfg.cpp
+++ b/python/bindings/py_structured_sdfg.cpp
@@ -495,10 +495,7 @@ void PyStructuredSDFG::schedule(const docc::target::TargetOptions& options) {
         dce.run(builder, analysis_manager);
     }
 
-    auto mapped = schedulers | std::views::transform([&](auto& n) { return n.get(); });
-    std::vector<sdfg::passes::scheduler::LoopScheduler*> unwrapped_schedulers(mapped.begin(), mapped.end());
-
-    sdfg::passes::scheduler::LoopSchedulingPass loop_scheduling_pass(unwrapped_schedulers, nullptr);
+    sdfg::passes::scheduler::LoopSchedulingPass loop_scheduling_pass(schedulers, nullptr);
     bool loop_scheduling_changes = loop_scheduling_pass.run(builder, analysis_manager);
     if (loop_scheduling_changes) {
         sdfg::passes::DataTransferMinimizationPass data_transfer_minimization_pass;

--- a/rpc/include/sdfg/passes/rpc/rpc_scheduler.h
+++ b/rpc/include/sdfg/passes/rpc/rpc_scheduler.h
@@ -16,6 +16,7 @@ private:
     const std::string target_;
     const std::string category_;
     const bool print_steps_;
+    bool dump_rpc_cutouts_;
 
 public:
     scheduler::SchedulerAction find(

--- a/rpc/include/sdfg/transformations/rpc_node_transform.h
+++ b/rpc/include/sdfg/transformations/rpc_node_transform.h
@@ -29,6 +29,7 @@ private:
     std::unique_ptr<passes::rpc::RpcOptResponse> opt_resp_;
 
     bool dump_steps_;
+    bool dump_rpc_cutouts_;
 
     std::string get_node_id_str() const;
 
@@ -43,7 +44,8 @@ public:
         const std::string& target,
         const std::string& category,
         sdfg::passes::rpc::RpcContext& rpc_context,
-        bool print_steps = false
+        bool print_steps = false,
+        bool dump_rpc_cutouts = false
     );
 
     virtual std::string name() const override;

--- a/rpc/src/passes/rpc/rpc_scheduler.cpp
+++ b/rpc/src/passes/rpc/rpc_scheduler.cpp
@@ -12,7 +12,7 @@ RPCScheduler::RPCScheduler(
     std::shared_ptr<rpc::RpcContext> rpc_context, std::string target, std::string category, bool print_steps
 )
     : LoopScheduler(), rpc_context_(std::move(rpc_context)), target_(std::move(target)), category_(std::move(category)),
-      print_steps_(print_steps) {}
+      print_steps_(print_steps), dump_rpc_cutouts_(false) {}
 
 scheduler::SchedulerAction RPCScheduler::find(
     builder::StructuredSDFGBuilder& builder,
@@ -60,7 +60,7 @@ bool RPCScheduler::can_apply_schedule(
     structured_control_flow::StructuredLoop& loop,
     bool offload_unknown_sizes
 ) {
-    transformations::RPCNodeTransform rpc_transform(loop, target_, category_, *rpc_context_);
+    transformations::RPCNodeTransform rpc_transform(loop, target_, category_, *rpc_context_, dump_rpc_cutouts_);
     rpc_transform.set_report(report_);
     return rpc_transform.can_be_applied(builder, analysis_manager);
 }
@@ -71,7 +71,8 @@ void RPCScheduler::apply_schedule(
     structured_control_flow::StructuredLoop& loop,
     bool offload_unknown_sizes
 ) {
-    transformations::RPCNodeTransform rpc_transform(loop, target_, category_, *rpc_context_, print_steps_);
+    transformations::RPCNodeTransform
+        rpc_transform(loop, target_, category_, *rpc_context_, print_steps_, dump_rpc_cutouts_);
     rpc_transform.set_report(report_);
     if (rpc_transform.can_be_applied(builder, analysis_manager)) {
         rpc_transform.apply(builder, analysis_manager);

--- a/rpc/src/transformations/rpc_node_transform.cpp
+++ b/rpc/src/transformations/rpc_node_transform.cpp
@@ -20,6 +20,7 @@
 #include "sdfg/transformations/replayer.h"
 #include "sdfg/transformations/rpc_node_transform.h"
 #include "sdfg/transformations/transformation.h"
+#include "sdfg/visualizer/dot_visualizer.h"
 
 namespace sdfg {
 namespace transformations {
@@ -30,9 +31,11 @@ RPCNodeTransform::RPCNodeTransform(
     const std::string& target,
     const std::string& category,
     sdfg::passes::rpc::RpcContext& rpc_context,
-    bool dump_steps
+    bool dump_steps,
+    bool dump_rpc_cutouts
 )
-    : node_(node), target_(target), category_(category), rpc_context_(rpc_context), dump_steps_(dump_steps) {}
+    : node_(node), target_(target), category_(category), rpc_context_(rpc_context), dump_steps_(dump_steps),
+      dump_rpc_cutouts_(dump_rpc_cutouts) {}
 
 std::string RPCNodeTransform::name() const { return "RPCNodeTransform"; }
 
@@ -63,6 +66,19 @@ bool RPCNodeTransform::
     // Create cutout SDFG
     std::unique_ptr<sdfg::StructuredSDFG> loop_sdfg = util::cutout(builder.subject(), analysis_manager, this->node_);
 
+    if (dump_rpc_cutouts_) {
+        auto dir = builder.subject().metadata_if_exists("output_dir");
+        if (dir) {
+            std::filesystem::path o = *dir;
+            std::filesystem::path subdir = o / ("rpc_" + std::to_string(node_.element_id()));
+            std::filesystem::create_directories(subdir);
+
+            auto file_name = "rpc_request." + target_ + "." + category_ + ".sdfg";
+            visualizer::DotVisualizer::writeToFile(*loop_sdfg, subdir / (file_name + ".dot"));
+            serializer::JSONSerializer::writeToFile(*loop_sdfg, subdir / (file_name + ".json"));
+        }
+    }
+
     // Loop info is only used for information on the loop structure
     auto opt_resp = query_rpc_server(
         {.sdfg = *loop_sdfg, .category = this->category_, .target = this->target_, .loop_info = loop_info}, rpc_context_
@@ -75,6 +91,19 @@ bool RPCNodeTransform::
 
     bool can_apply = this->opt_resp_ != nullptr &&
                      (this->opt_resp_->sdfg_result.has_value() || this->opt_resp_->local_replay.has_value());
+
+    if (dump_rpc_cutouts_ && this->opt_resp_ && this->opt_resp_->sdfg_result) {
+        auto dir = builder.subject().metadata_if_exists("output_dir");
+        if (dir) {
+            std::filesystem::path o = *dir;
+            std::filesystem::path subdir = o / ("rpc_" + std::to_string(node_.element_id()));
+            auto& response = this->opt_resp_->sdfg_result.value().sdfg;
+
+            auto file_name = "rpc_response." + target_ + "." + category_ + ".sdfg";
+            visualizer::DotVisualizer::writeToFile(*response, subdir / (file_name + ".dot"));
+            serializer::JSONSerializer::writeToFile(*response, subdir / (file_name + ".json"));
+        }
+    }
 
     if (report_) {
         if (!can_apply) {
@@ -275,6 +304,7 @@ void RPCNodeTransform::
 
 
 void RPCNodeTransform::to_json(nlohmann::json& j) const {
+    j["applied_to_element_id"] = node_.element_id();
     j["transformation_type"] = name();
     nlohmann::json params = {{"target", target_}, {"category", category_}, {"speedup", opt_resp_->metadata.speedup}};
     if (opt_resp_->metadata.region_id.has_value()) {

--- a/sdfg/include/sdfg/plugins/plugins.h
+++ b/sdfg/include/sdfg/plugins/plugins.h
@@ -83,6 +83,17 @@ public:
         };
     }
 
+    static std::unique_ptr<Context> global_context_ptr() {
+        return std::make_unique<Context>(
+            serializer::LibraryNodeSerializerRegistry::instance(),
+            codegen::NodeDispatcherRegistry::instance(),
+            codegen::MapDispatcherRegistry::instance(),
+            codegen::ReduceDispatcherRegistry::instance(),
+            codegen::LibraryNodeDispatcherRegistry::instance(),
+            passes::scheduler::SchedulerRegistry::instance()
+        );
+    }
+
     bool add_target(docc::target::DoccTarget* target) {
         auto res = available_targets.insert_or_assign(target->short_name, target);
         return res.second;

--- a/sdfg/src/visualizer/dot_visualizer.cpp
+++ b/sdfg/src/visualizer/dot_visualizer.cpp
@@ -1,5 +1,6 @@
 #include "sdfg/visualizer/dot_visualizer.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <string>
 #include <utility>
@@ -370,7 +371,17 @@ void DotVisualizer::visualizeDataFlowGraph(const std::string& id, const data_flo
         }
 
         std::unordered_set<std::string> unused_connectors(in_connectors.begin(), in_connectors.end());
-        for (const data_flow::Memlet& iedge : dfg.in_edges(*node)) {
+        auto _in_edges = dfg.in_edges(*node);
+        std::vector<const data_flow::Memlet*> sorted_edges;
+        for (const data_flow::Memlet& iedge : _in_edges) {
+            sorted_edges.push_back(&iedge);
+        }
+        std::sort(sorted_edges.begin(), sorted_edges.end(), [](const data_flow::Memlet* a, const data_flow::Memlet* b) {
+            if (a->src().element_id() != b->src().element_id()) return a->src().element_id() < b->src().element_id();
+            return a->dst().element_id() < b->dst().element_id();
+        });
+        for (const data_flow::Memlet* iedge_ptr : sorted_edges) {
+            const data_flow::Memlet& iedge = *iedge_ptr;
             auto& src = iedge.src();
             auto& dst_conn = iedge.dst_conn();
             bool nonexistent_conn = false;


### PR DESCRIPTION
## Description
 * dot_viz sorts edges deterministically. Makes .dot files more deterministic
 + Context can also produce a shared_ptr of the context
 + RPCNodeTransform can optionally dump the cutout and response into sub-folders for debugging (default off, using output_dir metadata on sdfg)
 * updated llvm frontend to use DoccTargets and construct RpcLoopScheduler fresh when needed
 * updated llvm frontend to use the docc context for access to DoccTargets (no it vectorizes again)
 + added "applied_to_element_id" field to RPCNodeTransform reporting, so that we can identify which level of a loop nest was actually tuned
~ replaced global PassReportCollector with thread-safe management that creates reports per module.

## Related Issues

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor / internal change (no functional change)
- [ ] Documentation update

## Quality Checklist
*Please ensure the following are completed before requesting review:*

* [x] Runtime-compatible (no externally visible existing method has its parameters changed, was deleted or has its exception behavior changed)
* [ ] Compile-time compatible (new arguments & properties added have default values, but users need to recompile against the new version to work)

IR:
* [ ] Introduces new types into the SDFG IR
* [ ]  Changed / added properties on SDFG IR Elements (LibraryNodes, ControlFlowNodes DataFlowNodes etc.)
  *  [ ] New / modified types have serialization / deserialization support
  *  [ ] Deserialization is backward compatible (new serialization can deserialize old format and represent it in the new format if applicable)
  *  [ ] Serialized format is backward compatible (previous deserializer can read new serialized format without incorrectness (just lacking additional guarantees that are optional or did not exist before)
  *  [ ] Serializer has an option to emit the previous format

### Unit Tests
- [ ] New unit tests have been added for the changes.
- [ ] Existing unit tests pass locally.
- [ ] Edge cases and error paths are covered.

### Integration Tests
- [ ] New integration tests have been added (or existing ones updated).
- [ ] Integration tests pass locally.
- [ ] Interactions with other components/services are verified.

### Documentation
- [ ] Public APIs, options, and behavior changes are documented.
- [ ] README / docs site / inline comments updated where applicable.
- [ ] Changelog / release notes updated (if applicable).

### Test Coverage
- [ ] Test coverage has not decreased as a result of this change.
- [ ] Coverage report reviewed and acceptable.
- [ ] Critical / new code paths are covered.

## How Has This Been Tested?
