### PR TITLE
Makes LocalStorage reduce-aware

### DIFF
--- a/opt/include/sdfg/targets/gpu/gpu_offload_reduce_dispatcher.h
+++ b/opt/include/sdfg/targets/gpu/gpu_offload_reduce_dispatcher.h
@@ -116,6 +116,10 @@ protected:
     // (x * y * z). Sizes the per-thread shared buffer for a multi-dimensional block.
     symbolic::Expression reduce_block_size_product();
 
+    // Name of the shared partials buffer for @p container: the schedule's
+    // partial_container property when set, else the invented __daisy_reduce_smem_<c>.
+    std::string partials_buffer_name(const std::string& container);
+
     void dispatch_reduction_declarations(
         codegen::LanguageExtension& language_extension,
         codegen::PrettyPrinter& stream,

--- a/opt/include/sdfg/targets/gpu/gpu_offload_reduce_dispatcher.h
+++ b/opt/include/sdfg/targets/gpu/gpu_offload_reduce_dispatcher.h
@@ -138,6 +138,21 @@ protected:
         TargetLevel target_level
     );
 
+    // Whether the body of a block-level shared reduction for @p container accumulates into
+    // a per-thread register partial (published to shared once after the coverage loop)
+    // instead of read-modify-writing shared each iteration. Applies only to a standalone
+    // block level that solely owns the body (no enclosing block reduce, no nested block
+    // reduce, no nested warp reduce). This keeps the hot accumulation in a register so the
+    // FMA chain is not serialized through shared memory; the existing shared tree/shuffle
+    // combine is unchanged.
+    bool uses_register_partial(TargetLevel target_level, const std::string& container);
+
+    // Publish each register partial to its shared slot once, after the coverage loop and
+    // before the combine (a single st.shared per thread instead of one per element).
+    void dispatch_reduction_publish(
+        codegen::LanguageExtension& language_extension, codegen::PrettyPrinter& stream, TargetLevel target_level
+    );
+
     virtual codegen::LanguageExtension& create_kernel_language_extension() = 0;
 
     virtual int get_warp_size() const = 0;

--- a/opt/include/sdfg/targets/gpu/gpu_offload_schedule_type.h
+++ b/opt/include/sdfg/targets/gpu/gpu_offload_schedule_type.h
@@ -59,6 +59,56 @@ inline TargetLevel target_level_from_string(const std::string& value) {
 }
 
 /**
+ * @brief Where a reduction's per-thread partials live, and hence how they combine.
+ *
+ * Orthogonal to the TargetLevel (which fixes the cooperation *scope*): the
+ * strategy fixes the *mechanism*.
+ * - Register: per-thread/lane register; a warp scope folds via __shfl_xor_sync.
+ * - Shared:   NV_Shared buffer + block halving tree.
+ * - Global:   per-thread register merged atomically into the global accumulator.
+ */
+enum class ReduceStrategy { Register, Shared, Global };
+
+inline std::string reduce_strategy_to_string(ReduceStrategy strategy) {
+    switch (strategy) {
+        case ReduceStrategy::Register:
+            return "register";
+        case ReduceStrategy::Shared:
+            return "shared";
+        case ReduceStrategy::Global:
+            return "global";
+    }
+    throw InvalidSDFGException("Invalid ReduceStrategy");
+}
+
+inline ReduceStrategy reduce_strategy_from_string(const std::string& value) {
+    if (value == "register") {
+        return ReduceStrategy::Register;
+    } else if (value == "shared") {
+        return ReduceStrategy::Shared;
+    } else if (value == "global") {
+        return ReduceStrategy::Global;
+    }
+    throw InvalidSDFGException("Invalid ReduceStrategy: " + value);
+}
+
+// The mechanism a target level uses by default: warp -> register+shuffle,
+// block -> shared tree, grid -> global atomics. Reproduces the historical
+// (pre-partial_storage) codegen when the property is unset.
+inline ReduceStrategy default_reduce_strategy(TargetLevel target_level) {
+    switch (target_level) {
+        case TargetLevel::WARP:
+            return ReduceStrategy::Register;
+        case TargetLevel::X_BLOCK:
+        case TargetLevel::Y_BLOCK:
+        case TargetLevel::Z_BLOCK:
+            return ReduceStrategy::Shared;
+        default:
+            return ReduceStrategy::Global;
+    }
+}
+
+/**
  * @brief Base class for GPU schedule types (CUDA/ROCm) using CRTP pattern
  *
  * This template class provides shared functionality for both CUDA and ROCm
@@ -120,6 +170,45 @@ public:
      */
     static void nested_sync(structured_control_flow::ScheduleType& schedule, const bool nested_sync) {
         schedule.set_property("nested_sync", nested_sync ? "true" : "false");
+    }
+
+    /**
+     * @brief Where this (reduction) schedule's partials live / how they combine.
+     *        Defaults from the target level when unset (backward compatible).
+     */
+    static ReduceStrategy partial_storage(const structured_control_flow::ScheduleType& schedule) {
+        auto it = schedule.properties().find("partial_storage");
+        if (it == schedule.properties().end()) {
+            return default_reduce_strategy(target_level(schedule));
+        }
+        return reduce_strategy_from_string(it->second);
+    }
+
+    /**
+     * @brief Set the reduction partial-storage strategy.
+     */
+    static void partial_storage(structured_control_flow::ScheduleType& schedule, const ReduceStrategy strategy) {
+        schedule.set_property("partial_storage", reduce_strategy_to_string(strategy));
+    }
+
+    /**
+     * @brief Name of the SDFG container holding this reduction's shared partials.
+     *
+     * Empty (the default) means the reduce dispatcher invents the buffer as
+     * `__daisy_reduce_smem_<accumulator>`. A non-empty value lets an external
+     * placement transform own the buffer's name (and, in time, share it with a
+     * staging buffer); the dispatcher then emits/addresses that name instead.
+     */
+    static std::string partial_container(const structured_control_flow::ScheduleType& schedule) {
+        auto it = schedule.properties().find("partial_container");
+        return it == schedule.properties().end() ? std::string() : it->second;
+    }
+
+    /**
+     * @brief Set the container name for this reduction's shared partials.
+     */
+    static void partial_container(structured_control_flow::ScheduleType& schedule, const std::string& container) {
+        schedule.set_property("partial_container", container);
     }
 
     /**

--- a/opt/include/sdfg/transformations/local_storage.h
+++ b/opt/include/sdfg/transformations/local_storage.h
@@ -144,6 +144,11 @@ public:
         bool loop_is_outermost = false; ///< the localized loop is the outermost loop
         bool loop_is_gpu = false; ///< the localized loop itself is GPU-scheduled
         bool has_gpu_descendant = false; ///< a GPU map lives inside the loop body
+        /// The localized loop is itself a GPU map and a block-scheduled loop in its
+        /// body consumes the tile: stage once per block into shared, reused by the
+        /// (sibling) consumers below (e.g. fused softmax: cache the row, then
+        /// max-reduce / sum-reduce / normalize all read from shared).
+        bool enclosing_cooperative = false;
 
         /// True when a GPU-scheduled loop encloses us (we are inside a device kernel).
         bool inside_gpu_kernel() const {
@@ -377,6 +382,17 @@ private:
         const types::IType& pointer_type,
         const std::vector<symbolic::Expression>& slot_indices,
         bool leading_barrier
+    );
+
+    /// Stage the tile once at the top of the localized GPU map's body (a
+    /// block-scheduled copy map + trailing barrier), so the block consumers below
+    /// read the shared buffer. Used for the enclosing-cooperative case.
+    void emit_enclosing_cooperative_copy_in(
+        builder::StructuredSDFGBuilder& builder,
+        analysis::AnalysisManager& analysis_manager,
+        const TileBuffer& buffer,
+        const types::IType& buffer_type,
+        const types::IType& pointer_type
     );
 
     /// Redirect every container access in the loop body to the local buffer,

--- a/opt/include/sdfg/transformations/local_storage.h
+++ b/opt/include/sdfg/transformations/local_storage.h
@@ -10,6 +10,7 @@
 #include "sdfg/data_flow/data_flow_graph.h"
 #include "sdfg/data_flow/memlet.h"
 #include "sdfg/structured_control_flow/control_flow_node.h"
+#include "sdfg/structured_control_flow/reduce.h"
 #include "sdfg/structured_control_flow/structured_loop.h"
 #include "sdfg/symbolic/symbolic.h"
 #include "sdfg/targets/gpu/gpu_offload_schedule_type.h"
@@ -327,15 +328,35 @@ public:
      * @brief Whether @p container is the accumulator of a Reduce enclosing,
      *        nested within, or equal to @p loop.
      *
-     * Reduction accumulators are staged and combined by the Reduce node + reduce
-     * dispatcher (registers / shared / global partials, tree / shuffle / atomic
-     * combine). LocalStorage stages read-only operands only and must never also
-     * localize an accumulator, so it rejects any such container.
+     * Detects the reduction-accumulator relationship. Localizing such a
+     * container is permitted only for a *non-cooperative* (sequential /
+     * per-thread) Reduce at or below @p loop — see @ref collect_reduction_owners
+     * — where LocalStorage privatizes the accumulator and apply() retargets the
+     * Reduce's descriptor to the local buffer. A cooperatively-combined
+     * (GPU-offloaded) Reduce is owned by the reduce dispatcher and must not be
+     * localized here.
      */
     static bool is_reduction_accumulator(
         structured_control_flow::StructuredLoop& loop,
         const std::string& container,
         analysis::AnalysisManager& analysis_manager
+    );
+
+    /**
+     * @brief Collect the non-cooperative Reduce nodes (@p loop itself or a
+     *        descendant) that reduce into @p container, for accumulator
+     *        privatization.
+     *
+     * @return false if a *cooperative* (GPU-combined) Reduce or an *ancestor*
+     *         Reduce owns @p container — those cannot be safely localized at
+     *         @p loop and must reject. Otherwise fills @p out with the owning
+     *         non-cooperative Reduce nodes (possibly empty) and returns true.
+     */
+    static bool collect_reduction_owners(
+        structured_control_flow::StructuredLoop& loop,
+        const std::string& container,
+        analysis::AnalysisManager& analysis_manager,
+        std::vector<structured_control_flow::Reduce*>& out
     );
 
 private:
@@ -347,6 +368,8 @@ private:
     TileInfo tile_info_; ///< Populated by can_be_applied()
     LocalityPlan plan_; ///< Schedule classification (populated by can_be_applied)
     std::unordered_set<const data_flow::Memlet*> group_memlets_; ///< Memlets in the selected tile group
+    std::vector<structured_control_flow::Reduce*> reduce_retargets_; ///< non-cooperative Reduce nodes to retarget in
+                                                                     ///< apply()
     bool container_read_ = false; ///< Container is read in the loop (set by can_be_applied)
     bool container_written_ = false; ///< Container is written in the loop (set by can_be_applied)
 

--- a/opt/include/sdfg/transformations/local_storage.h
+++ b/opt/include/sdfg/transformations/local_storage.h
@@ -438,6 +438,9 @@ public:
     /// JSON serialization.
     void to_json(nlohmann::json& j) const override;
 
+    /// JSON deserialization.
+    static LocalStorage from_json(builder::StructuredSDFGBuilder& builder, const nlohmann::json& j);
+
     /// Name of the created local buffer (valid after apply()).
     const std::string& local_container() const { return local_name_; }
 

--- a/opt/src/targets/gpu/gpu_offload_reduce_dispatcher.cpp
+++ b/opt/src/targets/gpu/gpu_offload_reduce_dispatcher.cpp
@@ -555,6 +555,9 @@ void GPUOffloadReduceDispatcher::dispatch_kernel_body(
     library_stream.setIndent(library_stream.indent() - 4);
     library_stream << "}" << std::endl;
 
+    // Publish per-thread register partials to their shared slots once, before the combine.
+    this->dispatch_reduction_publish(kernel_language_extension, library_stream, target_level);
+
     // Combine the per-thread / per-warp partials for this level into the accumulator.
     this->dispatch_reduction_combine(kernel_language_extension, library_stream, library_snippet_factory, target_level);
 }
@@ -797,6 +800,38 @@ std::string GPUOffloadReduceDispatcher::partials_buffer_name(const std::string& 
     return placed.empty() ? ("__daisy_reduce_smem_" + container) : placed;
 }
 
+bool GPUOffloadReduceDispatcher::uses_register_partial(TargetLevel target_level, const std::string& container) {
+    if (!is_block_level(target_level)) {
+        return false;
+    }
+    if (gpu::ScheduleType_GPU_Offload::partial_storage(node_.schedule_type()) != ReduceStrategy::Shared) {
+        return false;
+    }
+    // The register partial requires this to be the sole block level owning the container's
+    // body: no nested warp reduce (which emits the body itself), no nested block reduce (which
+    // owns the body and shadows the accumulator onto shared, leaving the register at identity
+    // so the publish would clobber the shared result), and no enclosing block reduce (which
+    // already declares the shared buffer, so a register partial here would redeclare it).
+    return !has_nested_warp_reduction(container) && !has_nested_block_reduction(container) &&
+           !has_enclosing_block_reduction(container);
+}
+
+void GPUOffloadReduceDispatcher::dispatch_reduction_publish(
+    codegen::LanguageExtension& language_extension, codegen::PrettyPrinter& stream, TargetLevel target_level
+) {
+    std::string lin_tid = reduce_linear_thread_index(language_extension);
+    for (const auto& r : node_.reductions()) {
+        if (!uses_register_partial(target_level, r.container)) {
+            continue;
+        }
+        std::string reg_name = "__daisy_reduce_reg_" + r.container;
+        std::string smem_name = partials_buffer_name(r.container);
+        stream << smem_name << "[" << lin_tid << "] = " << reg_name << ";" << std::endl;
+    }
+    // No sync here: the combine's leading __syncthreads() (emit_block_tree) makes every
+    // thread's published slot visible before any neighbour slot is read.
+}
+
 void GPUOffloadReduceDispatcher::dispatch_reduction_declarations(
     codegen::LanguageExtension& language_extension,
     codegen::PrettyPrinter& stream,
@@ -838,6 +873,13 @@ void GPUOffloadReduceDispatcher::dispatch_reduction_declarations(
         if (strategy != ReduceStrategy::Shared) {
             // Register / Global: a per-thread (or per-lane) partial in a register.
             stream << ctype << " " << reg_name << " = " << identity << ";" << std::endl;
+        } else if (uses_register_partial(target_level, r.container)) {
+            // Block shared, but accumulate the body in a per-thread register partial and
+            // publish it to shared once after the coverage loop (dispatch_reduction_publish),
+            // so the FMA chain is not serialized through shared memory. No pre-coverage init
+            // or sync: the publish fills every slot and syncs before the combine reads them.
+            stream << ctype << " " << reg_name << " = " << identity << ";" << std::endl;
+            stream << "__shared__ " << ctype << " " << smem_name << "[" << block_size << "];" << std::endl;
         } else if (!has_enclosing_block_reduction(r.container)) {
             // Only the outermost block level owning this container declares the single shared
             // buffer; every inner block level folds into that same buffer. Declaring one per
@@ -880,8 +922,9 @@ void GPUOffloadReduceDispatcher::dispatch_reduction_shadow(
         std::string reg_name = "__daisy_reduce_reg_" + r.container;
         std::string smem_name = partials_buffer_name(r.container);
 
-        std::string storage = (strategy == ReduceStrategy::Shared) ? ("&" + smem_name + "[" + lin_tid + "]")
-                                                                   : ("&" + reg_name);
+        std::string storage = (strategy == ReduceStrategy::Shared && !uses_register_partial(target_level, r.container))
+                                  ? ("&" + smem_name + "[" + lin_tid + "]")
+                                  : ("&" + reg_name);
 
         auto index = accumulator_index(node_.root(), r.container, node_.indvar());
         if (symbolic::eq(index, symbolic::zero())) {

--- a/opt/src/targets/gpu/gpu_offload_reduce_dispatcher.cpp
+++ b/opt/src/targets/gpu/gpu_offload_reduce_dispatcher.cpp
@@ -257,7 +257,10 @@ void GPUOffloadReduceDispatcher::dispatch_node(
     std::vector<std::string> arguments;
 
     for (auto& argument : used_arguments) {
-        if (!sdfg_.type(argument.first).storage_type().is_nv_symbol()) {
+        auto storage = sdfg_.type(argument.first).storage_type();
+        // Thread-index symbols and shared-memory scratch (a kernel-local placed partials
+        // buffer) are declared inside the kernel, never passed as kernel arguments.
+        if (!storage.is_nv_symbol() && !storage.is_nv_shared()) {
             arguments.push_back(argument.first);
         }
     }
@@ -420,6 +423,42 @@ void GPUOffloadReduceDispatcher::dispatch_kernel_body(
     TargetLevel target_level = gpu::ScheduleType_GPU_Offload::target_level(node_.schedule_type());
     std::string coverage_loop_var = "__daisy_gpu_coverage_loop_" + gpu::to_string(target_level);
     std::string size = kernel_language_extension.expression(node_.num_iterations());
+
+    // The partial-storage strategy fixes the combine mechanism; only these (scope, mechanism)
+    // pairs are supported: warp+Register (shuffle), block+Shared (tree), block/grid+Global
+    // (atomics). Others (e.g. a shared tree at grid scope, a shuffle off a warp) have no
+    // lowering and must fail loudly rather than emit undefined code.
+    ReduceStrategy strategy = gpu::ScheduleType_GPU_Offload::partial_storage(node_.schedule_type());
+    if (strategy == ReduceStrategy::Register && target_level != TargetLevel::WARP) {
+        throw InvalidSDFGException("GPUOffloadReduceDispatcher: Register partial storage is only valid at WARP level");
+    }
+    if (strategy == ReduceStrategy::Shared && !is_block_level(target_level)) {
+        throw InvalidSDFGException("GPUOffloadReduceDispatcher: Shared partial storage is only valid at block levels");
+    }
+    if (strategy == ReduceStrategy::Global && target_level == TargetLevel::WARP) {
+        throw InvalidSDFGException("GPUOffloadReduceDispatcher: Global partial storage is not valid at WARP level");
+    }
+
+    // A placed partials container (partial_container) is a shared buffer; it only applies to
+    // the shared-tree mechanism, names a single reduction's buffer, and — when it already
+    // exists in the SDFG — must be NV_Shared storage.
+    std::string placed_partials = gpu::ScheduleType_GPU_Offload::partial_container(node_.schedule_type());
+    if (!placed_partials.empty()) {
+        if (strategy != ReduceStrategy::Shared) {
+            throw InvalidSDFGException("GPUOffloadReduceDispatcher: partial_container requires Shared partial storage");
+        }
+        if (node_.reductions().size() != 1) {
+            throw InvalidSDFGException(
+                "GPUOffloadReduceDispatcher: partial_container names a single buffer but the reduce carries "
+                "multiple reductions"
+            );
+        }
+        if (sdfg_.exists(placed_partials) && !sdfg_.type(placed_partials).storage_type().is_nv_shared()) {
+            throw InvalidSDFGException(
+                "GPUOffloadReduceDispatcher: placed partials container '" + placed_partials + "' must be NV_Shared"
+            );
+        }
+    }
 
     // Declare this level's reduction partials (registers for WARP/GRID, shared memory for
     // BLOCK) and initialize them to each operator's identity element.
@@ -753,15 +792,18 @@ symbolic::Expression GPUOffloadReduceDispatcher::reduce_block_size_product() {
             symbolic::mul(reduce_block_dim(TargetLevel::Y_BLOCK), reduce_block_dim(TargetLevel::Z_BLOCK)));
 }
 
+std::string GPUOffloadReduceDispatcher::partials_buffer_name(const std::string& container) {
+    std::string placed = gpu::ScheduleType_GPU_Offload::partial_container(node_.schedule_type());
+    return placed.empty() ? ("__daisy_reduce_smem_" + container) : placed;
+}
+
 void GPUOffloadReduceDispatcher::dispatch_reduction_declarations(
     codegen::LanguageExtension& language_extension,
     codegen::PrettyPrinter& stream,
     codegen::CodeSnippetFactory& library_snippet_factory,
     TargetLevel target_level
 ) {
-    const bool grid = is_grid_level(target_level);
-    const bool block = is_block_level(target_level);
-    const bool warp = target_level == TargetLevel::WARP;
+    const ReduceStrategy strategy = gpu::ScheduleType_GPU_Offload::partial_storage(node_.schedule_type());
 
     // Every thread of a (possibly multi-dimensional) block owns a distinct shared slot,
     // addressed by its flat thread index; the buffer spans the whole block (x * y * z).
@@ -791,11 +833,12 @@ void GPUOffloadReduceDispatcher::dispatch_reduction_declarations(
         }
 
         std::string reg_name = "__daisy_reduce_reg_" + r.container;
-        std::string smem_name = "__daisy_reduce_smem_" + r.container;
+        std::string smem_name = partials_buffer_name(r.container);
 
-        if (grid || warp) {
+        if (strategy != ReduceStrategy::Shared) {
+            // Register / Global: a per-thread (or per-lane) partial in a register.
             stream << ctype << " " << reg_name << " = " << identity << ";" << std::endl;
-        } else if (block && !has_enclosing_block_reduction(r.container)) {
+        } else if (!has_enclosing_block_reduction(r.container)) {
             // Only the outermost block level owning this container declares the single shared
             // buffer; every inner block level folds into that same buffer. Declaring one per
             // level would create same-named shadows of which only the innermost is populated,
@@ -822,6 +865,7 @@ void GPUOffloadReduceDispatcher::dispatch_reduction_shadow(
     codegen::LanguageExtension& language_extension, codegen::PrettyPrinter& stream, TargetLevel target_level
 ) {
     const bool block = is_block_level(target_level);
+    const ReduceStrategy strategy = gpu::ScheduleType_GPU_Offload::partial_storage(node_.schedule_type());
     std::string lin_tid = reduce_linear_thread_index(language_extension);
 
     for (const auto& r : node_.reductions()) {
@@ -834,9 +878,10 @@ void GPUOffloadReduceDispatcher::dispatch_reduction_shadow(
         auto prim = accumulator_primitive(sdfg_, r.container);
         std::string ctype = language_extension.primitive_type(prim);
         std::string reg_name = "__daisy_reduce_reg_" + r.container;
-        std::string smem_name = "__daisy_reduce_smem_" + r.container;
+        std::string smem_name = partials_buffer_name(r.container);
 
-        std::string storage = block ? ("&" + smem_name + "[" + lin_tid + "]") : ("&" + reg_name);
+        std::string storage = (strategy == ReduceStrategy::Shared) ? ("&" + smem_name + "[" + lin_tid + "]")
+                                                                   : ("&" + reg_name);
 
         auto index = accumulator_index(node_.root(), r.container, node_.indvar());
         if (symbolic::eq(index, symbolic::zero())) {
@@ -854,9 +899,7 @@ void GPUOffloadReduceDispatcher::dispatch_reduction_combine(
     codegen::CodeSnippetFactory& library_snippet_factory,
     TargetLevel target_level
 ) {
-    const bool grid = is_grid_level(target_level);
-    const bool block = is_block_level(target_level);
-    const bool warp = target_level == TargetLevel::WARP;
+    const ReduceStrategy strategy = gpu::ScheduleType_GPU_Offload::partial_storage(node_.schedule_type());
 
     // A reduce reduces only along its own axis; every other block dimension is an
     // independent "row". Shared slots are addressed by the flat thread index, so the
@@ -869,12 +912,12 @@ void GPUOffloadReduceDispatcher::dispatch_reduction_combine(
         auto prim = accumulator_primitive(sdfg_, r.container);
         std::string ctype = language_extension.primitive_type(prim);
         std::string reg_name = "__daisy_reduce_reg_" + r.container;
-        std::string smem_name = "__daisy_reduce_smem_" + r.container;
+        std::string smem_name = partials_buffer_name(r.container);
         auto index = accumulator_index(node_.root(), r.container, node_.indvar());
         std::string target = "reinterpret_cast<" + ctype + " *>(" + r.container + ")[" +
                              language_extension.expression(index) + "]";
 
-        if (warp) {
+        if (strategy == ReduceStrategy::Register) {
             // Reduce the per-lane partials into every lane's register. The shuffle is read
             // once into a temporary before combining: emitting the __shfl_xor_sync inside a
             // combine expression (e.g. a min/max ternary) would duplicate it into divergent
@@ -925,7 +968,7 @@ void GPUOffloadReduceDispatcher::dispatch_reduction_combine(
                 stream.setIndent(stream.indent() - 4);
                 stream << "}" << std::endl;
             }
-        } else if (block) {
+        } else if (strategy == ReduceStrategy::Shared) {
             // Inner block levels only accumulate their per-thread partials into the single
             // shared buffer via the body; they emit no fold here. A block coverage loop of
             // an enclosing level iterates multiple times when count > parallel_size, so
@@ -1020,18 +1063,19 @@ void GPUOffloadReduceDispatcher::dispatch_reduction_combine(
                 stream.setIndent(stream.indent() - 4);
                 stream << "}" << std::endl;
             }
-        } else if (grid) {
-            // Atomics are exclusive to grid-level reductions. When the grid register is
-            // fed by a nested block/warp reduction of the same container, only the block's
-            // axis leaders hold a non-identity value (every other thread holds the operator
-            // identity), so committing every thread is correct. Otherwise the grid body is
-            // replicated verbatim across all block threads and each holds an identical copy
-            // of the partial; committing all of them would multiply the result by blockDim,
-            // so only one thread per block may commit. (For a pure grid reduction blockDim
-            // == 1, making the guard a no-op.)
+        } else if (strategy == ReduceStrategy::Global) {
+            // Atomic commit of each thread's register straight to the global accumulator.
+            // At a grid level with no nested block/warp reduce, the reduce body is replicated
+            // verbatim across all block threads and each holds an identical partial; committing
+            // all of them would multiply the result by blockDim, so a single thread commits.
+            // When fed by a nested block/warp reduction, only the axis leaders hold a
+            // non-identity value (every other thread holds the operator identity), so every
+            // thread may commit. At a block level (block+Global storage) each thread instead
+            // holds a *distinct* reduce-axis partial, so all of them must commit.
             bool fed_by_nested_reduction = has_nested_block_reduction(r.container) ||
                                            has_nested_warp_reduction(r.container);
-            if (!fed_by_nested_reduction) {
+            bool redundant_threads = is_grid_level(target_level) && !fed_by_nested_reduction;
+            if (redundant_threads) {
                 stream << "if (" << lin_tid << " == 0) {" << std::endl;
                 stream.setIndent(stream.indent() + 4);
             }
@@ -1043,7 +1087,7 @@ void GPUOffloadReduceDispatcher::dispatch_reduction_combine(
                 std::string helper = "__daisy_reduce_combine_" + op_tag(r.operation) + "_" + type_tag;
                 stream << helper << "(&" << target << ", " << reg_name << ");" << std::endl;
             }
-            if (!fed_by_nested_reduction) {
+            if (redundant_threads) {
                 stream.setIndent(stream.indent() - 4);
                 stream << "}" << std::endl;
             }

--- a/opt/src/transformations/local_storage.cpp
+++ b/opt/src/transformations/local_storage.cpp
@@ -141,6 +141,91 @@ public:
     }
 };
 
+/// First block-level GPU-offloaded loop in @p loop's body (a cooperative copy /
+/// consumer axis for enclosing-scope staging), or nullptr.
+structured_control_flow::StructuredLoop* find_block_scheduled_descendant(
+    structured_control_flow::StructuredLoop& loop, analysis::AnalysisManager& analysis_manager
+) {
+    auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();
+    for (auto* desc : loop_analysis.descendants(&loop)) {
+        auto* sl = dynamic_cast<structured_control_flow::StructuredLoop*>(desc);
+        if (!sl) {
+            continue;
+        }
+        auto& sched = sl->schedule_type();
+        if (sched.category() != structured_control_flow::ScheduleTypeCategory::Offloader) {
+            continue;
+        }
+        if (gpu::is_block_level(gpu::gpu_target_level(sched))) {
+            return sl;
+        }
+    }
+    return nullptr;
+}
+
+/// True if @p scope's body reads @p container in any block.
+bool scope_reads_container(structured_control_flow::ControlFlowNode& scope, const std::string& container) {
+    bool reads = false;
+    for_each_block(scope, [&](structured_control_flow::Block& block) {
+        for (auto* access : block.dataflow().data_nodes()) {
+            if (access->data() == container) {
+                reads = true;
+            }
+        }
+    });
+    return reads;
+}
+
+/// Block-level GPU-offloaded loops in @p loop's body that access @p container.
+std::vector<structured_control_flow::StructuredLoop*> block_scheduled_consumers(
+    structured_control_flow::StructuredLoop& loop,
+    const std::string& container,
+    analysis::AnalysisManager& analysis_manager
+) {
+    auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();
+    std::vector<structured_control_flow::StructuredLoop*> consumers;
+    for (auto* desc : loop_analysis.descendants(&loop)) {
+        auto* sl = dynamic_cast<structured_control_flow::StructuredLoop*>(desc);
+        if (!sl) {
+            continue;
+        }
+        auto& sched = sl->schedule_type();
+        if (sched.category() != structured_control_flow::ScheduleTypeCategory::Offloader) {
+            continue;
+        }
+        if (gpu::is_block_level(gpu::gpu_target_level(sched)) && scope_reads_container(sl->root(), container)) {
+            consumers.push_back(sl);
+        }
+    }
+    return consumers;
+}
+
+/// True if two tiles have the same per-dimension base and extent.
+bool same_tile_shape(const analysis::MemoryTile& a, const analysis::MemoryTile& b) {
+    if (a.min_subset.size() != b.min_subset.size()) {
+        return false;
+    }
+    for (size_t d = 0; d < a.min_subset.size(); d++) {
+        if (!symbolic::eq(a.min_subset[d], b.min_subset[d])) {
+            return false;
+        }
+    }
+    auto ea = a.extents_approx();
+    auto eb = b.extents_approx();
+    if (ea.size() != eb.size()) {
+        return false;
+    }
+    for (size_t d = 0; d < ea.size(); d++) {
+        if (ea[d].is_null() != eb[d].is_null()) {
+            return false;
+        }
+        if (!ea[d].is_null() && !symbolic::eq(ea[d], eb[d])) {
+            return false;
+        }
+    }
+    return true;
+}
+
 } // namespace
 
 std::vector<size_t> LocalStorage::TileInfo::varying_dims() const {
@@ -407,6 +492,15 @@ LocalStorage::LocalityPlan LocalStorage::build_locality_plan(
         }
         plan.dims.push_back(d);
     }
+
+    // Enclosing-scope cooperative staging: the localized loop is itself a GPU map
+    // with no enclosing parallel context, and a block-scheduled loop in its body
+    // consumes the tile. The tile is staged once per block into shared and reused
+    // by every (sibling) consumer below.
+    if (plan.dims.empty() && plan.loop_is_gpu && find_block_scheduled_descendant(loop, analysis_manager) != nullptr) {
+        plan.enclosing_cooperative = true;
+    }
+
     return plan;
 }
 
@@ -449,6 +543,11 @@ LocalStorage::Locality LocalStorage::derive_storage(const LocalityPlan& plan, bo
     // A cooperative CPU-parallel dim would need threads to share a stack — impossible.
     if (plan.has_cpu_cooperative()) {
         return Locality::Reject;
+    }
+    // Enclosing-scope staging: a per-block shared row loaded once, reused by the
+    // block consumers below. A cooperative write is a reduction (Reduce owns it).
+    if (plan.enclosing_cooperative) {
+        return container_written ? Locality::Reject : Locality::Shared;
     }
     if (plan.has_gpu_cooperative()) {
         // A cooperative write across threads is a reduction: that is owned by the
@@ -521,6 +620,53 @@ bool LocalStorage::can_be_applied(builder::StructuredSDFGBuilder& builder, analy
         return false;
     }
 
+    // Enclosing-scope cooperative staging: a read-only tile localized at a GPU map
+    // whose body has block-scheduled consumers. The tile is per-block (the map's own
+    // indvar is fixed per instance), so resolve its shape from the consumers — where
+    // that indvar is opaque — rather than at loop_, where it would unfold across the
+    // whole grid. Stage once, reuse across every sibling consumer below.
+    if (container_read_ && !container_written_) {
+        LocalityPlan topo = build_locality_plan(loop_, TileInfo{}, analysis_manager);
+        if (topo.enclosing_cooperative) {
+            auto consumers = block_scheduled_consumers(loop_, container_, analysis_manager);
+            if (consumers.empty()) {
+                return false;
+            }
+            const std::string& sched_value = consumers.front()->schedule_type().value();
+            if (sched_value != "CUDA_Offload" && sched_value != "ROCM_Offload") {
+                return false;
+            }
+            const analysis::MemoryTileGroup* ref = tile(*consumers.front(), container_, analysis_manager);
+            if (!ref || !is_constant_bounded(ref)) {
+                return false;
+            }
+            auto count = tile_element_count(ref);
+            auto budget = symbolic::integer(static_cast<int64_t>(max_tile_elements()));
+            if (count.is_null() || !symbolic::is_true(symbolic::Le(count, budget))) {
+                return false;
+            }
+            // Every block consumer must localize the same per-block tile; union their
+            // memlets so rewrite_body repoints all of them to the shared buffer.
+            group_memlets_.clear();
+            for (auto* c : consumers) {
+                const analysis::MemoryTileGroup* g = tile(*c, container_, analysis_manager);
+                if (!g || !same_tile_shape(g->tile, ref->tile)) {
+                    return false;
+                }
+                group_memlets_.insert(g->memlets.begin(), g->memlets.end());
+            }
+            auto& rt = ref->tile;
+            tile_info_.dimensions = rt.extents_approx();
+            tile_info_.bases = rt.min_subset;
+            tile_info_.strides =
+                std::vector<symbolic::Expression>(rt.layout.strides().begin(), rt.layout.strides().end());
+            tile_info_.offset = rt.layout.offset();
+            plan_ = topo;
+            storage_type_ = types::StorageType::NV_Shared();
+            return true;
+        }
+    }
+
     // Resolve the single localizable tile for the whole container.
     auto* group = tile(loop_, container_, analysis_manager);
     if (!group) {
@@ -563,6 +709,21 @@ bool LocalStorage::can_be_applied(builder::StructuredSDFGBuilder& builder, analy
             // read-only, and the cooperative Map is the loop's immediate enclosing loop.
             if (container_written_) {
                 return false;
+            }
+            if (plan_.enclosing_cooperative) {
+                // Enclosing-scope staging: the localized GPU map's body has a
+                // block-scheduled consumer supplying the copy schedule; the buffer is
+                // per-block shared, loaded once and reused by every sibling below.
+                auto* coop = find_block_scheduled_descendant(loop_, analysis_manager);
+                if (!coop) {
+                    return false;
+                }
+                const std::string& sched_value = coop->schedule_type().value();
+                if (sched_value != "CUDA_Offload" && sched_value != "ROCM_Offload") {
+                    return false;
+                }
+                storage_type_ = types::StorageType::NV_Shared();
+                break;
             }
             for (const auto& d : plan_.dims) {
                 if (!d.is_gpu || d.level != LocalityPlan::Level::Block) {
@@ -634,11 +795,17 @@ void LocalStorage::apply(builder::StructuredSDFGBuilder& builder, analysis::Anal
     builder.add_container(local_name_, buffer_type);
 
     if (storage_type_.is_nv_shared()) {
-        // Read-only cooperative tile: cooperative copy-in + barrier(s), no writeback.
-        // A per-thread slot prefix means the shared row is re-staged per kernel
-        // coverage iteration, so guard it with a leading barrier too.
-        bool leading_barrier = !slot_indices.empty();
-        emit_cooperative_copy_in(builder, *parent, buffer, buffer_type, pointer_type, slot_indices, leading_barrier);
+        if (plan_.enclosing_cooperative) {
+            // Stage the row once at the top of the localized GPU map's body; the
+            // (sibling) block consumers below read the shared buffer.
+            emit_enclosing_cooperative_copy_in(builder, analysis_manager, buffer, buffer_type, pointer_type);
+        } else {
+            // Read-only cooperative tile: cooperative copy-in + barrier(s), no writeback.
+            // A per-thread slot prefix means the shared row is re-staged per kernel
+            // coverage iteration, so guard it with a leading barrier too.
+            bool leading_barrier = !slot_indices.empty();
+            emit_cooperative_copy_in(builder, *parent, buffer, buffer_type, pointer_type, slot_indices, leading_barrier);
+        }
     } else {
         if (needs_copy_in()) {
             emit_private_copy(builder, *parent, buffer, buffer_type, pointer_type, /*writeback=*/false);
@@ -764,6 +931,51 @@ void LocalStorage::emit_cooperative_copy_in(
 
     // Barrier so every thread's load is visible before the tile is consumed.
     auto& barrier_block = builder.add_block_before(parent, loop_, loop_.debug_info());
+    builder.add_library_node<data_flow::BarrierLocalNode>(barrier_block, DebugInfo());
+}
+
+void LocalStorage::emit_enclosing_cooperative_copy_in(
+    builder::StructuredSDFGBuilder& builder,
+    analysis::AnalysisManager& analysis_manager,
+    const TileBuffer& buffer,
+    const types::IType& buffer_type,
+    const types::IType& pointer_type
+) {
+    // A block-scheduled consumer in the body supplies the copy schedule (verified in
+    // can_be_applied). The staged row is loaded once at the top of the body, then a
+    // barrier makes it visible before the sibling consumers read it.
+    auto* coop = find_block_scheduled_descendant(loop_, analysis_manager);
+    auto& body = loop_.root();
+    auto& first = body.at(0);
+
+    auto c_name = builder.find_new_name("__daisy_ls_coop_" + container_);
+    builder.add_container(c_name, types::Scalar(types::PrimitiveType::UInt64));
+    auto c = symbolic::symbol(c_name);
+
+    // Copy map: the block cooperatively splits the tile (one shared row, no slots).
+    auto& copy_map = builder.add_map_before(
+        body,
+        first,
+        c,
+        symbolic::Lt(c, buffer.tile_total_size()),
+        symbolic::integer(0),
+        symbolic::add(c, symbolic::integer(1)),
+        coop->schedule_type(),
+        loop_.debug_info()
+    );
+
+    auto decomp = buffer.delinearize_tile(c);
+    auto& block = builder.add_block(copy_map.root());
+    auto& src = builder.add_access(block, container_);
+    auto& dst = builder.add_access(block, local_name_);
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
+    data_flow::Subset dst_subset = {c};
+    builder.add_computational_memlet(block, src, tasklet, "_in", tile_info_.original_subset(decomp), pointer_type);
+    builder.add_computational_memlet(block, tasklet, "_out", dst, dst_subset, buffer_type);
+
+    // Trailing barrier (after the copy, before the consumers) — no leading barrier,
+    // the shared row is loaded once per block at body entry.
+    auto& barrier_block = builder.add_block_before(body, first, loop_.debug_info());
     builder.add_library_node<data_flow::BarrierLocalNode>(barrier_block, DebugInfo());
 }
 

--- a/opt/src/transformations/local_storage.cpp
+++ b/opt/src/transformations/local_storage.cpp
@@ -1049,5 +1049,30 @@ void LocalStorage::to_json(nlohmann::json& j) const {
     j["subgraph"]["1"]["type"] = "access_node";
 }
 
+LocalStorage LocalStorage::from_json(builder::StructuredSDFGBuilder& builder, const nlohmann::json& desc) {
+    auto loop_id = desc["subgraph"]["0"]["element_id"].get<size_t>();
+    auto element = builder.find_element_by_id(loop_id);
+    if (!element) {
+        throw InvalidTransformationDescriptionException("Element with ID " + std::to_string(loop_id) + " not found.");
+    }
+    auto loop = dyn_cast<structured_control_flow::StructuredLoop*>(element);
+    if (!loop) {
+        throw InvalidTransformationDescriptionException(
+            "Element with ID " + std::to_string(loop_id) + " is not a structured loop."
+        );
+    }
+
+    auto access_node = dynamic_cast<
+        data_flow::AccessNode*>(builder.find_element_by_id(desc.at("subgraph").at("1").at("element_id").get<size_t>()));
+    if (!access_node) {
+        throw InvalidTransformationDescriptionException(
+            "Access node with ID " + std::to_string(desc.at("subgraph").at("1").at("element_id").get<size_t>()) +
+            " not found."
+        );
+    }
+
+    return LocalStorage(*loop, *access_node);
+}
+
 } // namespace transformations
 } // namespace sdfg

--- a/opt/src/transformations/local_storage.cpp
+++ b/opt/src/transformations/local_storage.cpp
@@ -359,6 +359,12 @@ bool LocalStorage::has_side_effect(structured_control_flow::StructuredLoop& loop
             return;
         }
         for (auto* lib_node : block.dataflow().library_nodes()) {
+            // A __syncthreads barrier accesses no data (a control-only scheduling
+            // primitive), so it cannot reference the localized container and does
+            // not block staging — unlike genuine side effects (malloc/memset/…).
+            if (dynamic_cast<data_flow::BarrierLocalNode*>(lib_node)) {
+                continue;
+            }
             if (lib_node->side_effect()) {
                 found = true;
                 return;

--- a/opt/src/transformations/local_storage.cpp
+++ b/opt/src/transformations/local_storage.cpp
@@ -544,6 +544,59 @@ bool LocalStorage::is_reduction_accumulator(
     return false;
 }
 
+bool LocalStorage::collect_reduction_owners(
+    structured_control_flow::StructuredLoop& loop,
+    const std::string& container,
+    analysis::AnalysisManager& analysis_manager,
+    std::vector<structured_control_flow::Reduce*>& out
+) {
+    auto& loop_analysis = analysis_manager.get<analysis::LoopAnalysis>();
+    auto owns = [&](structured_control_flow::ControlFlowNode* node) -> structured_control_flow::Reduce* {
+        auto* reduce = dynamic_cast<structured_control_flow::Reduce*>(node);
+        if (!reduce) {
+            return nullptr;
+        }
+        for (const auto& r : reduce->reductions()) {
+            if (r.container == container) {
+                return reduce;
+            }
+        }
+        return nullptr;
+    };
+
+    // An ancestor Reduce accumulates across iterations *outside* the localized
+    // scope, so a buffer created at loop_ cannot span the accumulator's lifetime.
+    for (auto* node : loop_analysis.ancestors(&loop)) {
+        if (owns(node)) {
+            return false;
+        }
+    }
+
+    // loop_ itself or a descendant Reduce: privatizable only when the reduction is
+    // combined sequentially / per-thread. A GPU-offloaded Reduce is combined across
+    // threads by the reduce dispatcher, which owns the accumulator staging.
+    auto consider = [&](structured_control_flow::Reduce* reduce) -> bool {
+        if (gpu::is_gpu_schedule(reduce->schedule_type())) {
+            return false;
+        }
+        out.push_back(reduce);
+        return true;
+    };
+    if (auto* reduce = owns(&loop)) {
+        if (!consider(reduce)) {
+            return false;
+        }
+    }
+    for (auto* node : loop_analysis.descendants(&loop)) {
+        if (auto* reduce = owns(node)) {
+            if (!consider(reduce)) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 LocalStorage::Locality LocalStorage::derive_storage(const LocalityPlan& plan, bool container_written) {
     using Level = LocalityPlan::Level;
     // A cooperative CPU-parallel dim would need threads to share a stack — impossible.
@@ -600,11 +653,16 @@ bool LocalStorage::can_be_applied(builder::StructuredSDFGBuilder& builder, analy
         return false;
     }
 
-    // Reduction accumulators are staged and combined by the Reduce node + reduce
-    // dispatcher; LocalStorage stages read-only operands only and must not also
-    // localize an accumulator.
+    // A reduction accumulator may be localized only when the owning Reduce is
+    // non-cooperative (sequential / per-thread): LocalStorage privatizes the
+    // accumulator and apply() retargets the Reduce's descriptor to the local
+    // buffer. A cooperatively-combined (GPU-offloaded) Reduce, or one enclosing
+    // the localized scope, is left to the reduce dispatcher.
+    reduce_retargets_.clear();
     if (is_reduction_accumulator(loop_, container_, analysis_manager)) {
-        return false;
+        if (!collect_reduction_owners(loop_, container_, analysis_manager, reduce_retargets_)) {
+            return false;
+        }
     }
 
     // Classify the container's accesses directly from the dataflow.
@@ -822,6 +880,14 @@ void LocalStorage::apply(builder::StructuredSDFGBuilder& builder, analysis::Anal
     }
 
     rewrite_body(builder, analysis_manager, buffer, buffer_type, slot_indices);
+
+    // Privatized reduction accumulator: point each owning (non-cooperative) Reduce
+    // at the local buffer so its denormalized descriptor matches the rewritten
+    // dataflow. The copy-in seeds it from the original and the copy-out stores back.
+    for (auto* reduce : reduce_retargets_) {
+        reduce->replace_reduction_container(container_, local_name_);
+    }
+
     analysis_manager.invalidate_all();
 }
 

--- a/opt/src/transformations/replayer.cpp
+++ b/opt/src/transformations/replayer.cpp
@@ -4,6 +4,7 @@
 #include <sdfg/transformations/einsum_lift.h>
 #include <sdfg/transformations/einsum_promotion.h>
 #include <sdfg/transformations/in_local_storage.h>
+#include <sdfg/transformations/local_storage.h>
 #include <sdfg/transformations/loop_distribute.h>
 #include <sdfg/transformations/loop_interchange.h>
 #include <sdfg/transformations/loop_peeling.h>
@@ -54,6 +55,8 @@ void Replayer::replay(
             this->apply<transformations::LoopDistribute>(builder, analysis_manager, desc, skip_if_not_applicable);
         } else if (transformation_name == "LoopInterchange") {
             this->apply<transformations::LoopInterchange>(builder, analysis_manager, desc, skip_if_not_applicable);
+        } else if (transformation_name == "LocalStorage") {
+            this->apply<transformations::LocalStorage>(builder, analysis_manager, desc, skip_if_not_applicable);
         } else if (transformation_name == "OutLocalStorage") {
             this->apply<transformations::OutLocalStorage>(builder, analysis_manager, desc, skip_if_not_applicable);
         } else if (transformation_name == "InLocalStorage") {

--- a/opt/tests/CMakeLists.txt
+++ b/opt/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ set(TEST_FILES
     cuda/blas/cublas_test.cpp
     cuda/cuda_kernel_test.cpp
     cuda/cuda_reduce_dispatcher_test.cpp
+    cuda/cuda_offload_reduce_dispatcher_test.cpp
     cuda/softmax_dispatcher_test.cpp
     rocm/blas/rocblas_test.cpp
     rocm/rocm_library_nodes_test.cpp

--- a/opt/tests/cuda/cuda_offload_reduce_dispatcher_test.cpp
+++ b/opt/tests/cuda/cuda_offload_reduce_dispatcher_test.cpp
@@ -1,0 +1,202 @@
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <string>
+
+#include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/codegen/language_extensions/c_language_extension.h"
+#include "sdfg/data_flow/tasklet.h"
+#include "sdfg/structured_control_flow/reduce.h"
+#include "sdfg/symbolic/symbolic.h"
+#include "sdfg/targets/cuda/cuda.h"
+#include "sdfg/targets/cuda/cuda_offload_reduce_dispatcher.h"
+#include "sdfg/targets/gpu/gpu_offload_schedule_type.h"
+#include "sdfg/types/array.h"
+
+namespace sdfg::cuda {
+
+// Build a standalone block-level (X_BLOCK) offloaded reduction `acc[0] += A[i]`
+// and return the generated kernel body. When @p strategy is set it is written to
+// the reduce schedule's partial_storage property; otherwise the level default
+// (Shared for a block level) applies. When @p partial_container is non-empty it is
+// set as the placed partials-buffer name, optionally also declared as an NV_Shared
+// container (@p declare_partials).
+static std::string dispatch_block_reduce(
+    std::optional<gpu::ReduceStrategy> strategy,
+    const std::string& partial_container = "",
+    bool declare_partials = false
+) {
+    builder::StructuredSDFGBuilder builder("red", FunctionType_CPU);
+    auto& root = builder.subject().root();
+
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer pointer_type(types::StorageType::NV_Generic(), 0, "", base_desc);
+    types::Scalar int_desc(types::PrimitiveType::Int32);
+
+    builder.add_container("i", int_desc);
+    builder.add_container("A", pointer_type);
+    builder.add_container("acc", pointer_type);
+    if (declare_partials) {
+        types::Array partials_type(types::StorageType::NV_Shared(), 0, "", base_desc, symbolic::integer(32));
+        builder.add_container(partial_container, partials_type);
+    }
+
+    auto schedule = gpu::ScheduleType_GPU_Offload::create<
+        ScheduleType_CUDA_Offload>(gpu::TargetLevel::X_BLOCK, symbolic::integer(32));
+    if (strategy.has_value()) {
+        gpu::ScheduleType_GPU_Offload::partial_storage(schedule, *strategy);
+    }
+    if (!partial_container.empty()) {
+        gpu::ScheduleType_GPU_Offload::partial_container(schedule, partial_container);
+    }
+
+    auto& reduce = builder.add_reduce(
+        root,
+        symbolic::symbol("i"),
+        symbolic::Lt(symbolic::symbol("i"), symbolic::integer(100)),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("i"), symbolic::integer(1)),
+        {structured_control_flow::ReductionInfo{structured_control_flow::ReductionOperation::Add, "acc"}},
+        schedule
+    );
+
+    auto& block = builder.add_block(reduce.root());
+    auto& a_access = builder.add_access(block, "A");
+    auto& acc_in = builder.add_access(block, "acc");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::fp_add, "_out", {"_in0", "_in1"});
+    auto& acc_out = builder.add_access(block, "acc");
+    builder.add_computational_memlet(block, acc_in, tasklet, "_in0", {symbolic::zero()}, pointer_type);
+    builder.add_computational_memlet(block, a_access, tasklet, "_in1", {symbolic::symbol("i")}, pointer_type);
+    builder.add_computational_memlet(block, tasklet, "_out", acc_out, {symbolic::zero()}, pointer_type);
+
+    codegen::CLanguageExtension language_extension(builder.subject());
+    auto instrumentation = codegen::InstrumentationPlan::none(builder.subject());
+    auto arg_capture = codegen::ArgCapturePlan::none(builder.subject());
+    analysis::AnalysisManager analysis_manager(builder.subject());
+
+    CUDAOffloadReduceDispatcher
+        dispatcher(language_extension, builder.subject(), analysis_manager, reduce, *instrumentation, *arg_capture);
+
+    codegen::PrettyPrinter main_stream;
+    codegen::PrettyPrinter globals_stream;
+    codegen::CodeSnippetFactory library_snippet_factory;
+    dispatcher.dispatch_node(main_stream, globals_stream, library_snippet_factory);
+
+    EXPECT_EQ(library_snippet_factory.snippets().size(), 1u);
+    return library_snippet_factory.snippets().begin()->second.stream().str();
+}
+
+// Default block level → shared-memory halving tree, no atomics.
+TEST(CUDAOffloadReduceDispatcherTest, BlockLevelDefaultsToSharedTree) {
+    std::string kernel = dispatch_block_reduce(std::nullopt);
+
+    EXPECT_NE(kernel.find("__shared__ float __daisy_reduce_smem_acc[32]"), std::string::npos);
+    EXPECT_NE(kernel.find("__syncthreads()"), std::string::npos);
+    // The block result is assigned (single owner), not atomically merged.
+    EXPECT_EQ(kernel.find("atomicAdd"), std::string::npos);
+}
+
+// Explicit Shared strategy at a block level reproduces the default output.
+TEST(CUDAOffloadReduceDispatcherTest, BlockLevelExplicitSharedMatchesDefault) {
+    EXPECT_EQ(dispatch_block_reduce(gpu::ReduceStrategy::Shared), dispatch_block_reduce(std::nullopt));
+}
+
+// Global override at a block level → per-thread register merged via atomics, no
+// shared buffer and no single-committer guard (every thread holds a distinct
+// reduce-axis partial, so all of them commit).
+TEST(CUDAOffloadReduceDispatcherTest, BlockLevelGlobalUsesAtomicsNoShared) {
+    std::string kernel = dispatch_block_reduce(gpu::ReduceStrategy::Global);
+
+    EXPECT_EQ(kernel.find("__shared__"), std::string::npos);
+    EXPECT_NE(kernel.find("float __daisy_reduce_reg_acc = 0;"), std::string::npos);
+    EXPECT_NE(kernel.find("atomicAdd(&reinterpret_cast<float *>(acc)[0], __daisy_reduce_reg_acc);"), std::string::npos);
+    // Every thread commits (each holds a distinct reduce-axis partial): no single-committer guard.
+    EXPECT_EQ(kernel.find("threadIdx.x == 0"), std::string::npos);
+    // No halving tree (the shared-tree bound variable is never emitted).
+    EXPECT_EQ(kernel.find("__daisy_reduce_m_acc"), std::string::npos);
+}
+
+// Register strategy is warp-only; a block level must reject it loudly.
+TEST(CUDAOffloadReduceDispatcherTest, RegisterAtBlockLevelThrows) {
+    EXPECT_THROW(dispatch_block_reduce(gpu::ReduceStrategy::Register), InvalidSDFGException);
+}
+
+// A placed partial_container renames the shared buffer; the invented default name
+// no longer appears, and the placed name is declared once and addressed by the tree.
+TEST(CUDAOffloadReduceDispatcherTest, PlacedPartialContainerRenamesBuffer) {
+    std::string kernel = dispatch_block_reduce(std::nullopt, "__daisy_reduce_myBuf", /*declare_partials*/ true);
+
+    EXPECT_EQ(kernel.find("__daisy_reduce_smem_acc"), std::string::npos);
+    EXPECT_NE(kernel.find("__shared__ float __daisy_reduce_myBuf[32]"), std::string::npos);
+    // Declared exactly once (no clash with a scope-variable declaration path), and
+    // referenced again by init + tree.
+    size_t first_decl = kernel.find("__shared__ float __daisy_reduce_myBuf[32]");
+    EXPECT_EQ(kernel.find("__shared__ float __daisy_reduce_myBuf[32]", first_decl + 1), std::string::npos);
+    size_t count = 0;
+    for (size_t p = kernel.find("__daisy_reduce_myBuf"); p != std::string::npos;
+         p = kernel.find("__daisy_reduce_myBuf", p + 1)) {
+        count++;
+    }
+    EXPECT_GE(count, 3u); // declaration + identity init + halving tree
+}
+
+// A metadata-only placed name (no declared container) still just renames the buffer.
+TEST(CUDAOffloadReduceDispatcherTest, PlacedPartialContainerWithoutDeclarationRenames) {
+    std::string kernel = dispatch_block_reduce(std::nullopt, "__daisy_reduce_myBuf", /*declare_partials*/ false);
+    EXPECT_EQ(kernel.find("__daisy_reduce_smem_acc"), std::string::npos);
+    EXPECT_NE(kernel.find("__shared__ float __daisy_reduce_myBuf[32]"), std::string::npos);
+}
+
+// partial_container is a Shared-only concept: pairing it with Global must throw.
+TEST(CUDAOffloadReduceDispatcherTest, PlacedPartialContainerWithGlobalThrows) {
+    EXPECT_THROW(dispatch_block_reduce(gpu::ReduceStrategy::Global, "__daisy_reduce_myBuf", false), InvalidSDFGException);
+}
+
+// A placed container that exists but is not NV_Shared is rejected.
+TEST(CUDAOffloadReduceDispatcherTest, PlacedPartialContainerWrongStorageThrows) {
+    builder::StructuredSDFGBuilder builder("red", FunctionType_CPU);
+    auto& root = builder.subject().root();
+    types::Scalar base_desc(types::PrimitiveType::Float);
+    types::Pointer pointer_type(types::StorageType::NV_Generic(), 0, "", base_desc);
+    types::Scalar int_desc(types::PrimitiveType::Int32);
+    builder.add_container("i", int_desc);
+    builder.add_container("A", pointer_type);
+    builder.add_container("acc", pointer_type);
+    // CPU_Stack (not NV_Shared) partials container.
+    types::Array partials_type(base_desc, symbolic::integer(32));
+    builder.add_container("__daisy_reduce_myBuf", partials_type);
+
+    auto schedule = gpu::ScheduleType_GPU_Offload::create<
+        ScheduleType_CUDA_Offload>(gpu::TargetLevel::X_BLOCK, symbolic::integer(32));
+    gpu::ScheduleType_GPU_Offload::partial_container(schedule, "__daisy_reduce_myBuf");
+
+    auto& reduce = builder.add_reduce(
+        root,
+        symbolic::symbol("i"),
+        symbolic::Lt(symbolic::symbol("i"), symbolic::integer(100)),
+        symbolic::integer(0),
+        symbolic::add(symbolic::symbol("i"), symbolic::integer(1)),
+        {structured_control_flow::ReductionInfo{structured_control_flow::ReductionOperation::Add, "acc"}},
+        schedule
+    );
+    auto& block = builder.add_block(reduce.root());
+    auto& a_access = builder.add_access(block, "A");
+    auto& acc_in = builder.add_access(block, "acc");
+    auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::fp_add, "_out", {"_in0", "_in1"});
+    auto& acc_out = builder.add_access(block, "acc");
+    builder.add_computational_memlet(block, acc_in, tasklet, "_in0", {symbolic::zero()}, pointer_type);
+    builder.add_computational_memlet(block, a_access, tasklet, "_in1", {symbolic::symbol("i")}, pointer_type);
+    builder.add_computational_memlet(block, tasklet, "_out", acc_out, {symbolic::zero()}, pointer_type);
+
+    codegen::CLanguageExtension language_extension(builder.subject());
+    auto instrumentation = codegen::InstrumentationPlan::none(builder.subject());
+    auto arg_capture = codegen::ArgCapturePlan::none(builder.subject());
+    analysis::AnalysisManager analysis_manager(builder.subject());
+    CUDAOffloadReduceDispatcher
+        dispatcher(language_extension, builder.subject(), analysis_manager, reduce, *instrumentation, *arg_capture);
+    codegen::PrettyPrinter main_stream, globals_stream;
+    codegen::CodeSnippetFactory library_snippet_factory;
+    EXPECT_THROW(dispatcher.dispatch_node(main_stream, globals_stream, library_snippet_factory), InvalidSDFGException);
+}
+
+} // namespace sdfg::cuda

--- a/opt/tests/transformations/test_local_storage.cpp
+++ b/opt/tests/transformations/test_local_storage.cpp
@@ -2230,6 +2230,220 @@ TEST(LocalStorageTest, IsReductionAccumulator_EnclosingAndNested) {
     EXPECT_FALSE(LocalStorage::is_reduction_accumulator(loop_k, "other", am));
 }
 
+// collect_reduction_owners: a sequential (non-cooperative) Reduce at the localized
+// loop is privatizable — it is returned so apply() can retarget its descriptor.
+TEST(LocalStorageTest, CollectReductionOwners_SequentialAccepts) {
+    builder::StructuredSDFGBuilder builder("ls_collect_seq", FunctionType_CPU);
+    auto& seq = builder.subject().root();
+    types::Scalar loop_var(types::PrimitiveType::Int32);
+    types::Pointer ptr(types::StorageType::NV_Generic(), 0, "", types::Scalar(types::PrimitiveType::Float));
+    auto j = symbolic::symbol("j");
+    auto N = symbolic::symbol("N");
+    builder.add_container("N", loop_var, true);
+    builder.add_container("j", loop_var);
+    builder.add_container("acc", ptr);
+
+    auto& reduce_j = builder.add_reduce(
+        seq,
+        j,
+        symbolic::Lt(j, N),
+        symbolic::integer(0),
+        symbolic::add(j, symbolic::integer(1)),
+        {structured_control_flow::ReductionInfo{structured_control_flow::ReductionOperation::Add, "acc"}},
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+
+    analysis::AnalysisManager am(builder.subject());
+    std::vector<structured_control_flow::Reduce*> owners;
+    EXPECT_TRUE(LocalStorage::collect_reduction_owners(reduce_j, "acc", am, owners));
+    ASSERT_EQ(owners.size(), 1u);
+    EXPECT_EQ(owners.front(), &reduce_j);
+}
+
+// collect_reduction_owners: a GPU-offloaded (cooperatively combined) Reduce is
+// owned by the reduce dispatcher — reject.
+TEST(LocalStorageTest, CollectReductionOwners_CooperativeRejects) {
+    builder::StructuredSDFGBuilder builder("ls_collect_coop", FunctionType_CPU);
+    auto& seq = builder.subject().root();
+    types::Scalar loop_var(types::PrimitiveType::Int32);
+    types::Pointer ptr(types::StorageType::NV_Generic(), 0, "", types::Scalar(types::PrimitiveType::Float));
+    auto j = symbolic::symbol("j");
+    auto N = symbolic::symbol("N");
+    builder.add_container("N", loop_var, true);
+    builder.add_container("j", loop_var);
+    builder.add_container("acc", ptr);
+
+    auto block = gpu::ScheduleType_GPU_Offload::create<
+        cuda::ScheduleType_CUDA_Offload>(gpu::TargetLevel::X_BLOCK, symbolic::integer(32));
+    auto& reduce_j = builder.add_reduce(
+        seq,
+        j,
+        symbolic::Lt(j, N),
+        symbolic::integer(0),
+        symbolic::add(j, symbolic::integer(1)),
+        {structured_control_flow::ReductionInfo{structured_control_flow::ReductionOperation::Add, "acc"}},
+        block
+    );
+
+    analysis::AnalysisManager am(builder.subject());
+    std::vector<structured_control_flow::Reduce*> owners;
+    EXPECT_FALSE(LocalStorage::collect_reduction_owners(reduce_j, "acc", am, owners));
+}
+
+// collect_reduction_owners: an *ancestor* Reduce accumulates across iterations
+// outside the localized scope — a buffer created at loop_ cannot span it — reject.
+TEST(LocalStorageTest, CollectReductionOwners_AncestorRejects) {
+    builder::StructuredSDFGBuilder builder("ls_collect_ancestor", FunctionType_CPU);
+    auto& seq = builder.subject().root();
+    types::Scalar loop_var(types::PrimitiveType::Int32);
+    types::Pointer ptr(types::StorageType::NV_Generic(), 0, "", types::Scalar(types::PrimitiveType::Float));
+    auto j = symbolic::symbol("j");
+    auto k = symbolic::symbol("k");
+    auto N = symbolic::symbol("N");
+    auto K = symbolic::symbol("K");
+    builder.add_container("N", loop_var, true);
+    builder.add_container("K", loop_var, true);
+    builder.add_container("j", loop_var);
+    builder.add_container("k", loop_var);
+    builder.add_container("acc", ptr);
+
+    auto& reduce_j = builder.add_reduce(
+        seq,
+        j,
+        symbolic::Lt(j, N),
+        symbolic::integer(0),
+        symbolic::add(j, symbolic::integer(1)),
+        {structured_control_flow::ReductionInfo{structured_control_flow::ReductionOperation::Add, "acc"}},
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+    auto& loop_k =
+        builder
+            .add_for(reduce_j.root(), k, symbolic::Lt(k, K), symbolic::integer(0), symbolic::add(k, symbolic::integer(1)));
+
+    analysis::AnalysisManager am(builder.subject());
+    std::vector<structured_control_flow::Reduce*> owners;
+    EXPECT_FALSE(LocalStorage::collect_reduction_owners(loop_k, "acc", am, owners));
+}
+
+// Accumulator privatization: a sequential Reduce over j accumulates y[iO*CY+iI]
+// (per-iO block). Localizing y at the Reduce loads the block once, accumulates in
+// a Private buffer, writes back once, and retargets the Reduce's descriptor to it
+// (gemv --target sequential: LocalStorage(j, y) then vectorize the inner loop).
+TEST(LocalStorageTest, Apply_ReductionAccumulator_Sequential) {
+    builder::StructuredSDFGBuilder builder("ls_reduce_priv", FunctionType_CPU);
+    auto& seq = builder.subject().root();
+    types::Scalar loop_var(types::PrimitiveType::Int32);
+    types::Scalar elem(types::PrimitiveType::Float);
+    types::Pointer ptr(types::StorageType::NV_Generic(), 0, "", elem);
+    auto iO = symbolic::symbol("iO");
+    auto j = symbolic::symbol("j");
+    auto iI = symbolic::symbol("iI");
+    auto N = symbolic::symbol("N");
+    auto K = symbolic::symbol("K");
+    auto CY = symbolic::integer(2);
+    builder.add_container("N", loop_var, true);
+    builder.add_container("K", loop_var, true);
+    builder.add_container("x", ptr, true);
+    builder.add_container("y", ptr, true);
+    builder.add_container("iO", loop_var);
+    builder.add_container("j", loop_var);
+    builder.add_container("iI", loop_var);
+
+    auto& for_iO =
+        builder.add_for(seq, iO, symbolic::Lt(iO, N), symbolic::integer(0), symbolic::add(iO, symbolic::integer(1)));
+    auto& reduce_j = builder.add_reduce(
+        for_iO.root(),
+        j,
+        symbolic::Lt(j, K),
+        symbolic::integer(0),
+        symbolic::add(j, symbolic::integer(1)),
+        {structured_control_flow::ReductionInfo{structured_control_flow::ReductionOperation::Add, "y"}},
+        structured_control_flow::ScheduleType_Sequential::create()
+    );
+    auto& for_iI = builder.add_for(
+        reduce_j.root(), iI, symbolic::Lt(iI, CY), symbolic::integer(0), symbolic::add(iI, symbolic::integer(1))
+    );
+    // y[iO*CY + iI] += x[j]
+    auto idx = symbolic::add(symbolic::mul(iO, CY), iI);
+    auto& blk = builder.add_block(for_iI.root());
+    auto& y_in = builder.add_access(blk, "y");
+    auto& x_in = builder.add_access(blk, "x");
+    auto& y_out = builder.add_access(blk, "y");
+    auto& t = builder.add_tasklet(blk, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+    builder.add_computational_memlet(blk, y_in, t, "_in1", {idx}, ptr);
+    builder.add_computational_memlet(blk, x_in, t, "_in2", {j}, ptr);
+    builder.add_computational_memlet(blk, t, "_out", y_out, {idx}, ptr);
+
+    analysis::AnalysisManager am(builder.subject());
+    LocalStorage xform(reduce_j, y_out); // localize the accumulator at the reduce loop
+    ASSERT_TRUE(xform.can_be_applied(builder, am));
+    EXPECT_TRUE(xform.storage_type().is_cpu_stack()); // per-thread / sequential private buffer
+    xform.apply(builder, am);
+
+    auto buf = xform.local_container();
+    ASSERT_TRUE(builder.subject().exists(buf));
+
+    // The Reduce descriptor now points at the local buffer, matching the rewritten
+    // dataflow (denormalized container kept consistent).
+    ASSERT_EQ(reduce_j.reductions().size(), 1u);
+    EXPECT_EQ(reduce_j.reductions().front().container, buf);
+
+    // The accumulation body reads/writes the buffer, not y; y appears only in the
+    // copy-in / writeback maps that now bracket the reduce.
+    auto* body = dyn_cast<structured_control_flow::Block*>(&for_iI.root().at(0));
+    ASSERT_NE(body, nullptr);
+    EXPECT_TRUE(block_uses(*body, buf));
+    EXPECT_FALSE(block_uses(*body, "y"));
+}
+
+// A cooperatively-combined (GPU-offloaded) reduction accumulator is left to the
+// reduce dispatcher — can_be_applied must refuse to localize it.
+TEST(LocalStorageTest, CanApply_CooperativeReductionAccumulator_Rejects) {
+    builder::StructuredSDFGBuilder builder("ls_reduce_coop_reject", FunctionType_CPU);
+    auto& seq = builder.subject().root();
+    types::Scalar loop_var(types::PrimitiveType::Int32);
+    types::Pointer ptr(types::StorageType::NV_Generic(), 0, "", types::Scalar(types::PrimitiveType::Float));
+    auto row = symbolic::symbol("row");
+    auto j = symbolic::symbol("j");
+    auto R = symbolic::symbol("R");
+    auto Nc = symbolic::integer(32);
+    builder.add_container("R", loop_var, true);
+    builder.add_container("x", ptr, true);
+    builder.add_container("acc", ptr, true);
+    builder.add_container("row", loop_var);
+    builder.add_container("j", loop_var);
+
+    auto grid = gpu::ScheduleType_GPU_Offload::create<
+        cuda::ScheduleType_CUDA_Offload>(gpu::TargetLevel::X_GRID, symbolic::integer(1));
+    auto block = gpu::ScheduleType_GPU_Offload::create<
+        cuda::ScheduleType_CUDA_Offload>(gpu::TargetLevel::X_BLOCK, symbolic::integer(32));
+    auto& map_row =
+        builder
+            .add_map(seq, row, symbolic::Lt(row, R), symbolic::integer(0), symbolic::add(row, symbolic::integer(1)), grid);
+    // Cooperative block reduction acc[row] += x[row*32 + j].
+    auto& reduce_j = builder.add_reduce(
+        map_row.root(),
+        j,
+        symbolic::Lt(j, Nc),
+        symbolic::integer(0),
+        symbolic::add(j, symbolic::integer(1)),
+        {structured_control_flow::ReductionInfo{structured_control_flow::ReductionOperation::Add, "acc"}},
+        block
+    );
+    auto& blk = builder.add_block(reduce_j.root());
+    auto& acc_in = builder.add_access(blk, "acc");
+    auto& x_in = builder.add_access(blk, "x");
+    auto& acc_out = builder.add_access(blk, "acc");
+    auto& t = builder.add_tasklet(blk, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+    builder.add_computational_memlet(blk, acc_in, t, "_in1", {row}, ptr);
+    builder.add_computational_memlet(blk, x_in, t, "_in2", {symbolic::add(symbolic::mul(row, Nc), j)}, ptr);
+    builder.add_computational_memlet(blk, t, "_out", acc_out, {row}, ptr);
+
+    analysis::AnalysisManager am(builder.subject());
+    LocalStorage xform(reduce_j, acc_out);
+    EXPECT_FALSE(xform.can_be_applied(builder, am));
+}
+
 // =====================================================================
 // can_be_applied: schedule gate (end-to-end)
 // =====================================================================

--- a/opt/tests/transformations/test_local_storage.cpp
+++ b/opt/tests/transformations/test_local_storage.cpp
@@ -7,7 +7,9 @@
 #include "sdfg/builder/structured_sdfg_builder.h"
 #include "sdfg/data_flow/access_node.h"
 #include "sdfg/data_flow/library_nodes/barrier_local_node.h"
+#include "sdfg/data_flow/library_nodes/math/cmath/cmath_node.h"
 #include "sdfg/data_flow/library_nodes/metadata_node.h"
+#include "sdfg/data_flow/library_nodes/stdlib/memset.h"
 #include "sdfg/structured_control_flow/block.h"
 #include "sdfg/structured_control_flow/for.h"
 #include "sdfg/structured_control_flow/map.h"
@@ -1421,15 +1423,35 @@ TEST(LocalStorageTest, CanApply_SideEffect_Rejects) {
     builder.add_computational_memlet(block, a_in, t, "_in2", {i}, ptr);
     builder.add_computational_memlet(block, t, "_out", c_out, {}, elem);
 
-    // A side-effecting library node in the loop body.
+    // A genuine side-effecting library node (memset) in the loop body — unlike a
+    // bare __syncthreads barrier, which accesses no data and does not block staging.
     auto& se_block = builder.add_block(loop.root());
-    builder.add_library_node<data_flow::BarrierLocalNode>(se_block, DebugInfo());
+    builder.add_library_node<stdlib::MemsetNode>(se_block, DebugInfo(), symbolic::integer(0), symbolic::integer(4));
 
     EXPECT_TRUE(LocalStorage::has_side_effect(loop));
 
     analysis::AnalysisManager am(builder.subject());
     LocalStorage xform(loop, a_in);
     EXPECT_FALSE(xform.can_be_applied(builder, am));
+}
+
+// A __syncthreads barrier (no data connectors) is not a staging-blocking side
+// effect — needed so LocalStorage can stage a row across barrier-separated passes.
+TEST(LocalStorageTest, HasSideEffect_BarrierIgnored) {
+    builder::StructuredSDFGBuilder builder("ls_barrier_ok", FunctionType_CPU);
+    types::Scalar sym(types::PrimitiveType::UInt64);
+    auto i = symbolic::symbol("i");
+    auto& loop = builder.add_for(
+        builder.subject().root(),
+        i,
+        symbolic::Lt(i, symbolic::integer(8)),
+        symbolic::integer(0),
+        symbolic::add(i, symbolic::one())
+    );
+    auto& blk = builder.add_block(loop.root());
+    builder.add_library_node<data_flow::BarrierLocalNode>(blk, DebugInfo());
+
+    EXPECT_FALSE(LocalStorage::has_side_effect(loop));
 }
 
 /**
@@ -2066,6 +2088,106 @@ TEST(LocalStorageTest, Plan_GpuOffloadReduce_BlockLevel) {
 }
 
 // A reduction accumulator is owned by the Reduce node + reduce dispatcher;
+// A read-only row consumed by Reduce nodes (softmax-style: reduce-max via a
+// cmath fmax, reduce-sum, normalize) stages at the enclosing grid loop. The cmath
+// input must be no_capture, else the pointer analysis falsely flags X as aliased.
+TEST(LocalStorageTest, Gate_ReduceConsumerStaging_Accepts) {
+    builder::StructuredSDFGBuilder builder("ls_probe_reduce_consumer", FunctionType_CPU);
+    auto& seq = builder.subject().root();
+    types::Scalar loop_var(types::PrimitiveType::Int32);
+    types::Scalar elem(types::PrimitiveType::Float);
+    types::Pointer ptr(types::StorageType::NV_Generic(), 0, "", elem);
+    auto row = symbolic::symbol("row");
+    auto jr = symbolic::symbol("jr");
+    auto jn = symbolic::symbol("jn");
+    auto R = symbolic::symbol("R");
+    auto Nc = symbolic::integer(32);
+    builder.add_container("R", loop_var, true);
+    builder.add_container("X", ptr, true);
+    builder.add_container("Y", ptr, true);
+    builder.add_container("m", ptr, true);
+    builder.add_container("row", loop_var);
+    builder.add_container("jr", loop_var);
+    builder.add_container("jn", loop_var);
+
+    auto grid = gpu::ScheduleType_GPU_Offload::create<
+        cuda::ScheduleType_CUDA_Offload>(gpu::TargetLevel::X_GRID, symbolic::integer(1));
+    auto block = gpu::ScheduleType_GPU_Offload::create<
+        cuda::ScheduleType_CUDA_Offload>(gpu::TargetLevel::X_BLOCK, symbolic::integer(32));
+
+    auto& map_row =
+        builder
+            .add_map(seq, row, symbolic::Lt(row, R), symbolic::integer(0), symbolic::add(row, symbolic::integer(1)), grid);
+    // reduce-max over the row into m[row], reading X[row*32 + jr]
+    auto& reduce = builder.add_reduce(
+        map_row.root(),
+        jr,
+        symbolic::Lt(jr, Nc),
+        symbolic::integer(0),
+        symbolic::add(jr, symbolic::integer(1)),
+        {structured_control_flow::ReductionInfo{structured_control_flow::ReductionOperation::Max, "m"}},
+        block
+    );
+    auto& rblk = builder.add_block(reduce.root());
+    auto& m_in = builder.add_access(rblk, "m");
+    auto& x_r = builder.add_access(rblk, "X");
+    auto& m_out = builder.add_access(rblk, "m");
+    auto& rt = builder.add_library_node<
+        math::cmath::CMathNode>(rblk, DebugInfo(), math::cmath::CMathFunction::fmax, types::PrimitiveType::Float);
+    builder.add_computational_memlet(rblk, m_in, rt, "_in1", {row}, ptr);
+    builder.add_computational_memlet(rblk, x_r, rt, "_in2", {symbolic::add(symbolic::mul(row, Nc), jr)}, ptr);
+    builder.add_computational_memlet(rblk, rt, "_out", m_out, {row}, ptr);
+    // second reduce: sum over the row into s[row], reading X[row*32 + js]
+    auto js = symbolic::symbol("js");
+    builder.add_container("js", loop_var);
+    builder.add_container("s", ptr);
+    auto& reduce2 = builder.add_reduce(
+        map_row.root(),
+        js,
+        symbolic::Lt(js, Nc),
+        symbolic::integer(0),
+        symbolic::add(js, symbolic::integer(1)),
+        {structured_control_flow::ReductionInfo{structured_control_flow::ReductionOperation::Add, "s"}},
+        block
+    );
+    auto& r2blk = builder.add_block(reduce2.root());
+    auto& s_in = builder.add_access(r2blk, "s");
+    auto& x_s = builder.add_access(r2blk, "X");
+    auto& s_out = builder.add_access(r2blk, "s");
+    auto& st = builder.add_tasklet(r2blk, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+    builder.add_computational_memlet(r2blk, s_in, st, "_in1", {row}, ptr);
+    builder.add_computational_memlet(r2blk, x_s, st, "_in2", {symbolic::add(symbolic::mul(row, Nc), js)}, ptr);
+    builder.add_computational_memlet(r2blk, st, "_out", s_out, {row}, ptr);
+    // normalize map reading X[row*32 + jn]
+    auto& map_n = builder.add_map(
+        map_row.root(), jn, symbolic::Lt(jn, Nc), symbolic::integer(0), symbolic::add(jn, symbolic::integer(1)), block
+    );
+    auto& nblk = builder.add_block(map_n.root());
+    auto& x_n = builder.add_access(nblk, "X");
+    auto& y_n = builder.add_access(nblk, "Y");
+    builder.add_container("tmp", ptr);
+    auto& tmp_o = builder.add_access(nblk, "tmp");
+    auto& sub = builder.add_tasklet(nblk, data_flow::TaskletCode::fp_sub, "_out", {"_in1", "_in2"});
+    auto& m_n = builder.add_access(nblk, "m");
+    builder.add_computational_memlet(nblk, x_n, sub, "_in1", {symbolic::add(symbolic::mul(row, Nc), jn)}, ptr);
+    builder.add_computational_memlet(nblk, m_n, sub, "_in2", {row}, ptr);
+    builder.add_computational_memlet(nblk, sub, "_out", tmp_o, {symbolic::integer(0)}, ptr);
+    auto& tmp_i = builder.add_access(nblk, "tmp");
+    auto& s_n = builder.add_access(nblk, "s");
+    auto& divt = builder.add_tasklet(nblk, data_flow::TaskletCode::fp_div, "_out", {"_in1", "_in2"});
+    builder.add_computational_memlet(nblk, tmp_i, divt, "_in1", {symbolic::integer(0)}, ptr);
+    builder.add_computational_memlet(nblk, s_n, divt, "_in2", {row}, ptr);
+    builder.add_computational_memlet(nblk, divt, "_out", y_n, {symbolic::add(symbolic::mul(row, Nc), jn)}, ptr);
+
+    analysis::AnalysisManager am(builder.subject());
+    auto plan = LocalStorage::build_locality_plan(map_row, LocalStorage::TileInfo{}, am);
+    EXPECT_TRUE(plan.enclosing_cooperative);
+    EXPECT_FALSE(LocalStorage::is_reduction_accumulator(map_row, "X", am));
+    // A cmath (fmax) reading X must not flag X as pointer-captured (no_capture).
+    LocalStorage xform(map_row, x_r);
+    EXPECT_TRUE(xform.can_be_applied(builder, am));
+}
+
 // is_reduction_accumulator detects it whether the Reduce is the loop itself, an
 // ancestor, or a descendant, so can_be_applied refuses to localize it.
 TEST(LocalStorageTest, IsReductionAccumulator_EnclosingAndNested) {

--- a/opt/tests/transformations/test_local_storage.cpp
+++ b/opt/tests/transformations/test_local_storage.cpp
@@ -2112,6 +2112,148 @@ TEST(LocalStorageTest, IsReductionAccumulator_EnclosingAndNested) {
 // can_be_applied: schedule gate (end-to-end)
 // =====================================================================
 
+// B1: fused-softmax staging topology — a read-only row X[row,:] staged at an
+// enclosing grid loop and reused by sibling block loops over the columns.
+// build_locality_plan flags this as enclosing_cooperative (a block consumer lives
+// below the localized GPU map), deriving a per-block NV_Shared row.
+TEST(LocalStorageTest, Gate_EnclosingCooperativeStaging_Accepts) {
+    builder::StructuredSDFGBuilder builder("ls_probe_softmax", FunctionType_CPU);
+    auto& seq = builder.subject().root();
+    types::Scalar loop_var(types::PrimitiveType::Int32);
+    types::Scalar elem(types::PrimitiveType::Float);
+    types::Pointer ptr(types::StorageType::NV_Generic(), 0, "", elem);
+    auto row = symbolic::symbol("row");
+    auto j1 = symbolic::symbol("j1");
+    auto j2 = symbolic::symbol("j2");
+    auto R = symbolic::symbol("R");
+    auto Nc = symbolic::integer(32); // row width: constant so the shared tile is fixed-size
+    builder.add_container("R", loop_var, true);
+    builder.add_container("X", ptr, true);
+    builder.add_container("Y1", ptr, true);
+    builder.add_container("Y2", ptr, true);
+    builder.add_container("row", loop_var);
+    builder.add_container("j1", loop_var);
+    builder.add_container("j2", loop_var);
+
+    auto grid = gpu::ScheduleType_GPU_Offload::create<
+        cuda::ScheduleType_CUDA_Offload>(gpu::TargetLevel::X_GRID, symbolic::integer(1));
+    auto block = gpu::ScheduleType_GPU_Offload::create<
+        cuda::ScheduleType_CUDA_Offload>(gpu::TargetLevel::X_BLOCK, symbolic::integer(32));
+
+    auto& map_row =
+        builder
+            .add_map(seq, row, symbolic::Lt(row, R), symbolic::integer(0), symbolic::add(row, symbolic::integer(1)), grid);
+    // Sibling 1: Y1[row*32 + j1] = X[row*32 + j1]
+    auto& map_j1 = builder.add_map(
+        map_row.root(), j1, symbolic::Lt(j1, Nc), symbolic::integer(0), symbolic::add(j1, symbolic::integer(1)), block
+    );
+    auto& blk1 = builder.add_block(map_j1.root());
+    auto& x_in1 = builder.add_access(blk1, "X");
+    auto& y1_out = builder.add_access(blk1, "Y1");
+    auto& t1 = builder.add_tasklet(blk1, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(blk1, x_in1, t1, "_in", {symbolic::add(symbolic::mul(row, Nc), j1)}, ptr);
+    builder.add_computational_memlet(blk1, t1, "_out", y1_out, {symbolic::add(symbolic::mul(row, Nc), j1)}, ptr);
+    // Sibling 2: Y2[row*32 + j2] = X[row*32 + j2]
+    auto& map_j2 = builder.add_map(
+        map_row.root(), j2, symbolic::Lt(j2, Nc), symbolic::integer(0), symbolic::add(j2, symbolic::integer(1)), block
+    );
+    auto& blk2 = builder.add_block(map_j2.root());
+    auto& x_in2 = builder.add_access(blk2, "X");
+    auto& y2_out = builder.add_access(blk2, "Y2");
+    auto& t2 = builder.add_tasklet(blk2, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(blk2, x_in2, t2, "_in", {symbolic::add(symbolic::mul(row, Nc), j2)}, ptr);
+    builder.add_computational_memlet(blk2, t2, "_out", y2_out, {symbolic::add(symbolic::mul(row, Nc), j2)}, ptr);
+
+    analysis::AnalysisManager am(builder.subject());
+
+    LocalStorage::TileInfo ti;
+    ti.bases = {symbolic::mul(row, Nc)};
+    auto plan = LocalStorage::build_locality_plan(map_row, ti, am);
+    EXPECT_TRUE(plan.dims.empty());
+    EXPECT_TRUE(plan.loop_is_gpu);
+    EXPECT_TRUE(plan.has_gpu_descendant);
+    EXPECT_TRUE(plan.enclosing_cooperative);
+    EXPECT_EQ(LocalStorage::derive_storage(plan, /*written*/ false), LocalStorage::Locality::Shared);
+    EXPECT_EQ(LocalStorage::derive_storage(plan, /*written*/ true), LocalStorage::Locality::Reject);
+
+    LocalStorage xform(map_row, x_in1);
+    EXPECT_TRUE(xform.can_be_applied(builder, am));
+}
+
+// B1 apply: the staged row is loaded once at the top of the grid body (copy map +
+// barrier), and BOTH sibling block loops read the shared buffer instead of X.
+TEST(LocalStorageTest, Apply_EnclosingCooperativeStaging) {
+    builder::StructuredSDFGBuilder builder("ls_apply_softmax", FunctionType_CPU);
+    auto& seq = builder.subject().root();
+    types::Scalar loop_var(types::PrimitiveType::Int32);
+    types::Scalar elem(types::PrimitiveType::Float);
+    types::Pointer ptr(types::StorageType::NV_Generic(), 0, "", elem);
+    auto row = symbolic::symbol("row");
+    auto j1 = symbolic::symbol("j1");
+    auto j2 = symbolic::symbol("j2");
+    auto R = symbolic::symbol("R");
+    auto Nc = symbolic::integer(32);
+    builder.add_container("R", loop_var, true);
+    builder.add_container("X", ptr, true);
+    builder.add_container("Y1", ptr, true);
+    builder.add_container("Y2", ptr, true);
+    builder.add_container("row", loop_var);
+    builder.add_container("j1", loop_var);
+    builder.add_container("j2", loop_var);
+
+    auto grid = gpu::ScheduleType_GPU_Offload::create<
+        cuda::ScheduleType_CUDA_Offload>(gpu::TargetLevel::X_GRID, symbolic::integer(1));
+    auto block = gpu::ScheduleType_GPU_Offload::create<
+        cuda::ScheduleType_CUDA_Offload>(gpu::TargetLevel::X_BLOCK, symbolic::integer(32));
+
+    auto& map_row =
+        builder
+            .add_map(seq, row, symbolic::Lt(row, R), symbolic::integer(0), symbolic::add(row, symbolic::integer(1)), grid);
+    auto& map_j1 = builder.add_map(
+        map_row.root(), j1, symbolic::Lt(j1, Nc), symbolic::integer(0), symbolic::add(j1, symbolic::integer(1)), block
+    );
+    auto& blk1 = builder.add_block(map_j1.root());
+    auto& x_in1 = builder.add_access(blk1, "X");
+    auto& y1_out = builder.add_access(blk1, "Y1");
+    auto& t1 = builder.add_tasklet(blk1, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(blk1, x_in1, t1, "_in", {symbolic::add(symbolic::mul(row, Nc), j1)}, ptr);
+    builder.add_computational_memlet(blk1, t1, "_out", y1_out, {symbolic::add(symbolic::mul(row, Nc), j1)}, ptr);
+    auto& map_j2 = builder.add_map(
+        map_row.root(), j2, symbolic::Lt(j2, Nc), symbolic::integer(0), symbolic::add(j2, symbolic::integer(1)), block
+    );
+    auto& blk2 = builder.add_block(map_j2.root());
+    auto& x_in2 = builder.add_access(blk2, "X");
+    auto& y2_out = builder.add_access(blk2, "Y2");
+    auto& t2 = builder.add_tasklet(blk2, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(blk2, x_in2, t2, "_in", {symbolic::add(symbolic::mul(row, Nc), j2)}, ptr);
+    builder.add_computational_memlet(blk2, t2, "_out", y2_out, {symbolic::add(symbolic::mul(row, Nc), j2)}, ptr);
+
+    analysis::AnalysisManager am(builder.subject());
+    LocalStorage xform(map_row, x_in1);
+    ASSERT_TRUE(xform.can_be_applied(builder, am));
+    EXPECT_TRUE(xform.storage_type().is_nv_shared());
+    xform.apply(builder, am);
+
+    auto buf = xform.local_container();
+    ASSERT_TRUE(builder.subject().exists(buf));
+    EXPECT_TRUE(builder.subject().type(buf).storage_type().is_nv_shared());
+
+    // Grid body is now [copy_map (offload), barrier, map_j1, map_j2].
+    ASSERT_EQ(map_row.root().size(), 4u);
+    auto* copy_map = dyn_cast<structured_control_flow::Map*>(&map_row.root().at(0));
+    ASSERT_NE(copy_map, nullptr);
+    EXPECT_EQ(copy_map->schedule_type().category(), structured_control_flow::ScheduleTypeCategory::Offloader);
+    EXPECT_NE(dyn_cast<structured_control_flow::Block*>(&map_row.root().at(1)), nullptr); // barrier
+    EXPECT_NE(dyn_cast<structured_control_flow::Map*>(&map_row.root().at(2)), nullptr);
+    EXPECT_NE(dyn_cast<structured_control_flow::Map*>(&map_row.root().at(3)), nullptr);
+
+    // Both consumers now read the shared buffer, not X.
+    EXPECT_TRUE(block_uses(blk1, buf));
+    EXPECT_FALSE(block_uses(blk1, "X"));
+    EXPECT_TRUE(block_uses(blk2, buf));
+    EXPECT_FALSE(block_uses(blk2, "X"));
+}
+
 /**
  * Gate_GpuCooperativeRead_Rejects: a read-only tile that is cooperative across a
  * GPU thread dim derives to shared memory, whose apply path is not implemented

--- a/opt/tests/transformations/test_local_storage.cpp
+++ b/opt/tests/transformations/test_local_storage.cpp
@@ -2302,6 +2302,138 @@ TEST(LocalStorageTest, Gate_EnclosingCooperativeStaging_Accepts) {
     EXPECT_TRUE(xform.can_be_applied(builder, am));
 }
 
+// Register tiling (thread coarsening): a written accumulator C[iO*CY+iI] under a
+// coarse block dim iO, localized at the sequential reduction loop k, becomes a
+// per-thread CY-element Private (register) tile — the C_reg role of a GEMM
+// micro-kernel. iO is in the tile base (per-thread), so it is not cooperative.
+TEST(LocalStorageTest, Apply_RegisterTile_CoarsenedAccumulator) {
+    builder::StructuredSDFGBuilder builder("ls_reg_tile", FunctionType_CPU);
+    auto& seq = builder.subject().root();
+    types::Scalar loop_var(types::PrimitiveType::Int32);
+    types::Scalar elem(types::PrimitiveType::Float);
+    types::Pointer ptr(types::StorageType::NV_Generic(), 0, "", elem);
+    auto iO = symbolic::symbol("iO");
+    auto k = symbolic::symbol("k");
+    auto iI = symbolic::symbol("iI");
+    auto N = symbolic::symbol("N");
+    auto CY = symbolic::integer(2);
+    auto K = symbolic::integer(4);
+    builder.add_container("N", loop_var, true);
+    builder.add_container("A", ptr, true);
+    builder.add_container("C", ptr, true);
+    builder.add_container("iO", loop_var);
+    builder.add_container("k", loop_var);
+    builder.add_container("iI", loop_var);
+
+    auto blocksched = gpu::ScheduleType_GPU_Offload::create<
+        cuda::ScheduleType_CUDA_Offload>(gpu::TargetLevel::X_BLOCK, symbolic::integer(8));
+    auto& map_iO = builder.add_map(
+        seq, iO, symbolic::Lt(iO, N), symbolic::integer(0), symbolic::add(iO, symbolic::integer(1)), blocksched
+    );
+    auto& loop_k =
+        builder
+            .add_for(map_iO.root(), k, symbolic::Lt(k, K), symbolic::integer(0), symbolic::add(k, symbolic::integer(1)));
+    auto& loop_iI = builder.add_for(
+        loop_k.root(), iI, symbolic::Lt(iI, CY), symbolic::integer(0), symbolic::add(iI, symbolic::integer(1))
+    );
+    // C[iO*CY + iI] += A[k]
+    auto idx = symbolic::add(symbolic::mul(iO, CY), iI);
+    auto& blk = builder.add_block(loop_iI.root());
+    auto& c_in = builder.add_access(blk, "C");
+    auto& a_in = builder.add_access(blk, "A");
+    auto& c_out = builder.add_access(blk, "C");
+    auto& t = builder.add_tasklet(blk, data_flow::TaskletCode::fp_add, "_out", {"_in1", "_in2"});
+    builder.add_computational_memlet(blk, c_in, t, "_in1", {idx}, ptr);
+    builder.add_computational_memlet(blk, a_in, t, "_in2", {k}, ptr);
+    builder.add_computational_memlet(blk, t, "_out", c_out, {idx}, ptr);
+
+    analysis::AnalysisManager am(builder.subject());
+    LocalStorage xform(loop_k, c_out); // localize C at the reduction loop
+    ASSERT_TRUE(xform.can_be_applied(builder, am));
+    // Per-thread private register tile (not shared).
+    EXPECT_FALSE(xform.storage_type().is_nv_shared());
+    xform.apply(builder, am);
+
+    auto buf = xform.local_container();
+    ASSERT_TRUE(builder.subject().exists(buf));
+    EXPECT_FALSE(builder.subject().type(buf).storage_type().is_nv_shared());
+    // The accumulation body (inside the reduction loop) now reads/writes the
+    // register tile, not C; C only appears in the copy-in / writeback around it.
+    auto* inner_for = dyn_cast<structured_control_flow::For*>(&loop_k.root().at(0));
+    ASSERT_NE(inner_for, nullptr);
+    auto* body = dyn_cast<structured_control_flow::Block*>(&inner_for->root().at(0));
+    ASSERT_NE(body, nullptr);
+    EXPECT_TRUE(block_uses(*body, buf));
+    EXPECT_FALSE(block_uses(*body, "C"));
+}
+
+// Register tiling operand cache: a read-only operand A[iO*CY+iI] that is invariant
+// across an inner reuse loop jI is hoisted into a per-thread scalar register,
+// loaded once and reused across jI — the a_reg / b_reg role of a GEMM micro-kernel.
+TEST(LocalStorageTest, Apply_RegisterTile_OperandReuse) {
+    builder::StructuredSDFGBuilder builder("ls_operand_reuse", FunctionType_CPU);
+    auto& seq = builder.subject().root();
+    types::Scalar loop_var(types::PrimitiveType::Int32);
+    types::Scalar elem(types::PrimitiveType::Float);
+    types::Pointer ptr(types::StorageType::NV_Generic(), 0, "", elem);
+    auto iO = symbolic::symbol("iO");
+    auto iI = symbolic::symbol("iI");
+    auto jI = symbolic::symbol("jI");
+    auto N = symbolic::symbol("N");
+    auto CY = symbolic::integer(2);
+    auto CX = symbolic::integer(3);
+    builder.add_container("N", loop_var, true);
+    builder.add_container("A", ptr, true);
+    builder.add_container("Y", ptr, true);
+    builder.add_container("iO", loop_var);
+    builder.add_container("iI", loop_var);
+    builder.add_container("jI", loop_var);
+
+    auto blocksched = gpu::ScheduleType_GPU_Offload::create<
+        cuda::ScheduleType_CUDA_Offload>(gpu::TargetLevel::X_BLOCK, symbolic::integer(8));
+    auto& map_iO = builder.add_map(
+        seq, iO, symbolic::Lt(iO, N), symbolic::integer(0), symbolic::add(iO, symbolic::integer(1)), blocksched
+    );
+    auto& loop_iI = builder.add_for(
+        map_iO.root(), iI, symbolic::Lt(iI, CY), symbolic::integer(0), symbolic::add(iI, symbolic::integer(1))
+    );
+    auto& loop_jI = builder.add_for(
+        loop_iI.root(), jI, symbolic::Lt(jI, CX), symbolic::integer(0), symbolic::add(jI, symbolic::integer(1))
+    );
+    // Y[(iO*CY+iI)*CX + jI] = A[iO*CY+iI]  — A invariant across jI
+    auto a_idx = symbolic::add(symbolic::mul(iO, CY), iI);
+    auto y_idx = symbolic::add(symbolic::mul(symbolic::add(symbolic::mul(iO, CY), iI), CX), jI);
+    auto& blk = builder.add_block(loop_jI.root());
+    auto& a_in = builder.add_access(blk, "A");
+    auto& y_out = builder.add_access(blk, "Y");
+    auto& t = builder.add_tasklet(blk, data_flow::TaskletCode::assign, "_out", {"_in"});
+    builder.add_computational_memlet(blk, a_in, t, "_in", {a_idx}, ptr);
+    builder.add_computational_memlet(blk, t, "_out", y_out, {y_idx}, ptr);
+
+    analysis::AnalysisManager am(builder.subject());
+    LocalStorage xform(loop_jI, a_in); // cache A at the reuse loop
+    ASSERT_TRUE(xform.can_be_applied(builder, am));
+    EXPECT_FALSE(xform.storage_type().is_nv_shared()); // private register, not shared
+
+    xform.apply(builder, am);
+    auto buf = xform.local_container();
+    ASSERT_TRUE(builder.subject().exists(buf));
+
+    // The load is hoisted above jI: iI body is [copy-in(A->buf), jI-loop], and the
+    // jI body reads the register, not A.
+    ASSERT_EQ(loop_iI.root().size(), 2u);
+    auto* copy_block = dyn_cast<structured_control_flow::Block*>(&loop_iI.root().at(0));
+    ASSERT_NE(copy_block, nullptr);
+    EXPECT_TRUE(block_uses(*copy_block, "A"));
+    EXPECT_TRUE(block_uses(*copy_block, buf));
+    auto* jI_loop = dyn_cast<structured_control_flow::For*>(&loop_iI.root().at(1));
+    ASSERT_NE(jI_loop, nullptr);
+    auto* body = dyn_cast<structured_control_flow::Block*>(&jI_loop->root().at(0));
+    ASSERT_NE(body, nullptr);
+    EXPECT_TRUE(block_uses(*body, buf));
+    EXPECT_FALSE(block_uses(*body, "A"));
+}
+
 // B1 apply: the staged row is loaded once at the top of the grid body (copy map +
 // barrier), and BOTH sibling block loops read the shared buffer instead of X.
 TEST(LocalStorageTest, Apply_EnclosingCooperativeStaging) {

--- a/python/bindings/control_flow/py_control_flow.cpp
+++ b/python/bindings/control_flow/py_control_flow.cpp
@@ -245,6 +245,13 @@ void register_control_flow(py::module& m) {
         .value("WARP", sdfg::gpu::TargetLevel::WARP)
         .export_values();
 
+    // ReduceStrategy enum (where a reduction's partials live / how they combine)
+    py::enum_<sdfg::gpu::ReduceStrategy>(m, "ReduceStrategy")
+        .value("Register", sdfg::gpu::ReduceStrategy::Register)
+        .value("Shared", sdfg::gpu::ReduceStrategy::Shared)
+        .value("Global", sdfg::gpu::ReduceStrategy::Global)
+        .export_values();
+
     // DataTransferDirection enum (host/device transfers)
     py::enum_<sdfg::offloading::DataTransferDirection>(m, "DataTransferDirection")
         .value("D2H", sdfg::offloading::DataTransferDirection::D2H)
@@ -284,23 +291,51 @@ void register_control_flow(py::module& m) {
         )
         .def_static(
             "cuda_offload",
-            [](sdfg::gpu::TargetLevel target_level, int64_t parallel_size) {
-                return sdfg::cuda::ScheduleType_CUDA_Offload::create<
+            [](sdfg::gpu::TargetLevel target_level,
+               int64_t parallel_size,
+               py::object partial_storage,
+               py::object partial_container) {
+                auto schedule = sdfg::cuda::ScheduleType_CUDA_Offload::create<
                     sdfg::cuda::ScheduleType_CUDA_Offload>(target_level, sdfg::symbolic::integer(parallel_size));
+                if (!partial_storage.is_none()) {
+                    sdfg::gpu::ScheduleType_GPU_Offload::
+                        partial_storage(schedule, partial_storage.cast<sdfg::gpu::ReduceStrategy>());
+                }
+                if (!partial_container.is_none()) {
+                    sdfg::gpu::ScheduleType_GPU_Offload::partial_container(schedule, partial_container.cast<std::string>());
+                }
+                return schedule;
             },
             py::arg("target_level"),
             py::arg("parallel_size"),
-            "Create a CUDA offload schedule type for the given target level and parallel size"
+            py::arg("partial_storage") = py::none(),
+            py::arg("partial_container") = py::none(),
+            "Create a CUDA offload schedule type for the given target level and parallel size; for a "
+            "reduction, partial_storage (ReduceStrategy) and partial_container (buffer name) may be set"
         )
         .def_static(
             "rocm_offload",
-            [](sdfg::gpu::TargetLevel target_level, int64_t parallel_size) {
-                return sdfg::rocm::ScheduleType_ROCM_Offload::create<
+            [](sdfg::gpu::TargetLevel target_level,
+               int64_t parallel_size,
+               py::object partial_storage,
+               py::object partial_container) {
+                auto schedule = sdfg::rocm::ScheduleType_ROCM_Offload::create<
                     sdfg::rocm::ScheduleType_ROCM_Offload>(target_level, sdfg::symbolic::integer(parallel_size));
+                if (!partial_storage.is_none()) {
+                    sdfg::gpu::ScheduleType_GPU_Offload::
+                        partial_storage(schedule, partial_storage.cast<sdfg::gpu::ReduceStrategy>());
+                }
+                if (!partial_container.is_none()) {
+                    sdfg::gpu::ScheduleType_GPU_Offload::partial_container(schedule, partial_container.cast<std::string>());
+                }
+                return schedule;
             },
             py::arg("target_level"),
             py::arg("parallel_size"),
-            "Create a ROCm offload schedule type for the given target level and parallel size"
+            py::arg("partial_storage") = py::none(),
+            py::arg("partial_container") = py::none(),
+            "Create a ROCm offload schedule type for the given target level and parallel size; for a "
+            "reduction, partial_storage (ReduceStrategy) and partial_container (buffer name) may be set"
         )
         .def("__repr__", [](const ScheduleType& st) {
             std::ostringstream oss;

--- a/python/bindings/transformations/py_transformations.cpp
+++ b/python/bindings/transformations/py_transformations.cpp
@@ -19,6 +19,7 @@
 #include <sdfg/transformations/offloading/cuda_parallelize_nested_map.h>
 #include <sdfg/transformations/offloading/cuda_transform.h>
 #include <sdfg/transformations/offloading/gpu_offload_nested_loop.h>
+#include <sdfg/transformations/omp_transform.h>
 #include <sdfg/transformations/out_local_storage.h>
 #include <sdfg/transformations/recorder.h>
 #include <sdfg/transformations/tile_fusion.h>
@@ -344,6 +345,21 @@ void register_transformations(py::module& m) {
         .def("__repr__", [](const VectorizeTransform& t) {
             std::ostringstream oss;
             oss << "<VectorizeTransform name='" << t.name() << "'>";
+            return oss.str();
+        });
+
+    // OMPTransform transformation
+    py::class_<OMPTransform, Transformation>(m, "OMPTransform")
+        .def(
+            py::init<Map&>(),
+            py::arg("loop"),
+            "Create an OpenMP transformation.\n\n"
+            "Args:\n"
+            "    loop: The sequential loop to parallelize with OpenMP"
+        )
+        .def("__repr__", [](const OMPTransform& t) {
+            std::ostringstream oss;
+            oss << "<OMPTransform name='" << t.name() << "'>";
             return oss.str();
         });
 

--- a/python/tests/_gpu_offload_dispatcher_impl.py
+++ b/python/tests/_gpu_offload_dispatcher_impl.py
@@ -41,6 +41,7 @@ from docc.sdfg import (
     DataTransferDirection,
     Pointer,
     PrimitiveType,
+    ReduceStrategy,
     Scalar,
     ScheduleType,
     StorageType,
@@ -82,8 +83,15 @@ class GpuBackend:
     def storage(self):
         return self._storage()
 
-    def schedule(self, target_level, parallel_size):
-        return self._schedule(target_level, parallel_size)
+    def schedule(
+        self, target_level, parallel_size, partial_storage=None, partial_container=None
+    ):
+        return self._schedule(
+            target_level,
+            parallel_size,
+            partial_storage=partial_storage,
+            partial_container=partial_container,
+        )
 
     def offload(self, builder, *args, **kwargs):
         return getattr(builder, self._offload_method)(*args, **kwargs)
@@ -315,12 +323,22 @@ def build_offloaded_elementwise(backend, n, op, target_level, parallel_size):
     return builder.move()
 
 
-def build_offloaded_reduction(backend, n, op, target_level, parallel_size):
+def build_offloaded_reduction(
+    backend,
+    n,
+    op,
+    target_level,
+    parallel_size,
+    partial_storage=None,
+    partial_container=None,
+):
     """Build ``acc[0] = <op>_j A[j]`` as a single offloaded Reduce.
 
     The device accumulator is zero-/identity-initialised on the host and
-    copied H2D before the kernel, since a grid-level reduction combines into
-    the global slot with an atomic / CAS.
+    copied H2D before the kernel, since the reduction combines into the global
+    slot with an atomic / CAS (grid, or block+Global). ``partial_storage``
+    (ReduceStrategy) and ``partial_container`` (placed shared-buffer name) tune
+    the reduce schedule's mechanism / buffer.
     """
     builder = StructuredSDFGBuilder(f"offload_reduce_{op}")
 
@@ -381,7 +399,12 @@ def build_offloaded_reduction(backend, n, op, target_level, parallel_size):
         str(n),
         "1",
         [(op, "__daisy_dev_acc")],
-        backend.schedule(target_level, parallel_size),
+        backend.schedule(
+            target_level,
+            parallel_size,
+            partial_storage=partial_storage,
+            partial_container=partial_container,
+        ),
     )
     blk = builder.add_block()
     a = builder.add_access(blk, "__daisy_dev_A")
@@ -1987,6 +2010,50 @@ def register(namespace, backend):
         ref = numpy_reduce(a, op)
         np.testing.assert_allclose(acc[0], ref, rtol=1e-4, atol=1e-4)
 
+    @pytest.mark.parametrize(
+        "strategy,partial_container",
+        [
+            (ReduceStrategy.Shared, None),  # block halving tree in __shared__
+            (ReduceStrategy.Global, None),  # block partials merged via atomics
+            (
+                ReduceStrategy.Shared,
+                "__daisy_reduce_placed",
+            ),  # placed (renamed) shared buffer
+        ],
+        ids=["block_shared", "block_global", "block_shared_placed"],
+    )
+    @pytest.mark.parametrize("op", ["add", "mul", "min", "max"])
+    @pytest.mark.parametrize(
+        "n,parallel_size",
+        [
+            (1000, 256),  # ragged
+            (100, 32),  # ragged, non-power-of-two remainder
+            (1, 32),  # degenerate size-1 reduction axis
+        ],
+        ids=["1000x256", "100x32", "size1"],
+    )
+    def test_offload_reduce_block_strategy(
+        strategy, partial_container, op, n, parallel_size, tmp_path
+    ):
+        sdfg = build_offloaded_reduction(
+            backend,
+            n,
+            op,
+            TargetLevel.X_BLOCK,
+            parallel_size,
+            partial_storage=strategy,
+            partial_container=partial_container,
+        )
+        compiled = _compile(backend, sdfg, tmp_path / "reduce_block")
+
+        a = _rng_input(op, n, 1)
+        acc = np.full(1, _identity(op), dtype=np.float32)
+
+        compiled(a, acc)
+
+        ref = numpy_reduce(a, op)
+        np.testing.assert_allclose(acc[0], ref, rtol=1e-4, atol=1e-4)
+
     _map_scns = make_map_nest_scenarios(ws)
 
     @pytest.mark.parametrize(
@@ -2130,6 +2197,7 @@ def register(namespace, backend):
     namespace.update(
         test_offload_map=test_offload_map,
         test_offload_reduce=test_offload_reduce,
+        test_offload_reduce_block_strategy=test_offload_reduce_block_strategy,
         test_map_nest=test_map_nest,
         test_reduce_nest=test_reduce_nest,
         test_multi_reduction_one_node=test_multi_reduction_one_node,

--- a/python/tests/cuda/test_local_storage_cuda.py
+++ b/python/tests/cuda/test_local_storage_cuda.py
@@ -666,3 +666,107 @@ def test_local_storage_register_tile_gemm(M, N, K, TY, TX, CY, CX, tmp_path):
     compiled(A.reshape(-1), B.reshape(-1), C.reshape(-1))
 
     np.testing.assert_allclose(C, A @ B, rtol=1e-3, atol=1e-3)
+
+
+def _build_gemm_regtile_reduce(M, N, K, TY, TX, CY, CX):
+    """As ``_build_gemm_regtile`` but the k loop is a sequential ``Reduce`` node
+    (as the frontend emits for ``C[i,j] += ...``). Localizing C at the Reduce
+    privatizes the CY*CX accumulator into a per-thread register tile and retargets
+    the Reduce descriptor to it — the per-thread (non-cooperative) reduction path.
+    """
+    f = Scalar(PrimitiveType.Float)
+    host = Pointer(f)
+    dev = Pointer(f, StorageType.NV_Generic())
+    i32 = Scalar(PrimitiveType.Int32)
+
+    b = StructuredSDFGBuilder("ls_gemm_regtile_reduce")
+    for nm in ("A", "B", "C"):
+        b.add_container(nm, host, is_argument=True)
+    for nm in ("__daisy_dev_A", "__daisy_dev_B", "__daisy_dev_C"):
+        b.add_container(nm, dev, is_argument=False)
+    for nm in ("jO", "iO", "k", "iI", "jI"):
+        b.add_container(nm, i32)
+
+    def off(hc, dc, dirn, life, size):
+        b.add_cuda_offloading_block(hc, dc, dirn, life, dev, size)
+
+    nbA = f"{M * K} * {FLOAT_BYTES}"
+    nbB = f"{K * N} * {FLOAT_BYTES}"
+    nbC = f"{M * N} * {FLOAT_BYTES}"
+    for dc, sz in (
+        ("__daisy_dev_A", nbA),
+        ("__daisy_dev_B", nbB),
+        ("__daisy_dev_C", nbC),
+    ):
+        off(dc, dc, DataTransferDirection.NONE, BufferLifecycle.ALLOC, sz)
+    off("A", "__daisy_dev_A", DataTransferDirection.H2D, BufferLifecycle.NO_CHANGE, nbA)
+    off("B", "__daisy_dev_B", DataTransferDirection.H2D, BufferLifecycle.NO_CHANGE, nbB)
+    off("C", "__daisy_dev_C", DataTransferDirection.H2D, BufferLifecycle.NO_CHANGE, nbC)
+
+    b.begin_map(
+        "jO", "0", str(N // CX), "1", ScheduleType.cuda_offload(TargetLevel.X_BLOCK, TX)
+    )
+    b.begin_map(
+        "iO", "0", str(M // CY), "1", ScheduleType.cuda_offload(TargetLevel.Y_BLOCK, TY)
+    )
+    # Sequential per-thread reduction over k into the C accumulator.
+    k_loop = b.begin_reduce("k", "0", str(K), "1", [("add", "__daisy_dev_C")])
+    b.begin_for("iI", "0", str(CY), "1")
+    b.begin_for("jI", "0", str(CX), "1")
+    blk = b.add_block()
+    a = b.add_access(blk, "__daisy_dev_A")
+    bb = b.add_access(blk, "__daisy_dev_B")
+    c_in = b.add_access(blk, "__daisy_dev_C")
+    c_out = b.add_access(blk, "__daisy_dev_C")
+    t = b.add_tasklet(blk, TaskletCode.fp_fma, ["_in1", "_in2", "_in3"], ["_out"])
+    b.add_memlet(blk, a, "", t, "_in1", f"(iO*{CY} + iI)*{K} + k", dev)
+    b.add_memlet(blk, bb, "", t, "_in2", f"k*{N} + jO*{CX} + jI", dev)
+    b.add_memlet(blk, c_in, "", t, "_in3", f"(iO*{CY} + iI)*{N} + jO*{CX} + jI", dev)
+    b.add_memlet(blk, t, "_out", c_out, "", f"(iO*{CY} + iI)*{N} + jO*{CX} + jI", dev)
+    b.end_for()
+    b.end_for()
+    b.end_reduce()
+    b.end_map()
+    b.end_map()
+
+    off("C", "__daisy_dev_C", DataTransferDirection.D2H, BufferLifecycle.NO_CHANGE, nbC)
+    for dc in ("__daisy_dev_A", "__daisy_dev_B", "__daisy_dev_C"):
+        off(dc, dc, DataTransferDirection.NONE, BufferLifecycle.FREE, "0")
+
+    return b, k_loop, c_out
+
+
+@pytest.mark.parametrize(
+    "M,N,K,TY,TX,CY,CX",
+    [(8, 8, 4, 2, 2, 2, 2), (16, 16, 8, 4, 4, 2, 2), (8, 8, 3, 2, 2, 2, 2)],
+    ids=["8x8x4", "16x16x8", "8x8x3"],
+)
+def test_local_storage_register_tile_gemm_reduce(M, N, K, TY, TX, CY, CX, tmp_path):
+    builder, k_loop, c_out = _build_gemm_regtile_reduce(M, N, K, TY, TX, CY, CX)
+
+    am = AnalysisManager(builder)
+    xform = LocalStorage(k_loop, c_out)
+    assert xform.can_be_applied(
+        builder, am
+    ), "per-thread (sequential) reduction accumulator should localize"
+    xform.apply(builder, am)
+
+    sdfg = builder.move()
+    sdfg.validate()
+    output_dir = tmp_path / f"gemm_reduce_{M}x{N}x{K}"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    lib_path = sdfg._compile(str(output_dir), "cuda")
+
+    generated = "\n".join(p.read_text() for p in output_dir.rglob("*.cu"))
+    assert "__daisy_local_storage" in generated, "C register tile not emitted"
+
+    compiled = CompiledSDFG(lib_path, sdfg)
+
+    rng = np.random.default_rng(0)
+    A = rng.standard_normal((M, K)).astype(np.float32)
+    B = rng.standard_normal((K, N)).astype(np.float32)
+    C = np.zeros((M, N), dtype=np.float32)
+
+    compiled(A.reshape(-1), B.reshape(-1), C.reshape(-1))
+
+    np.testing.assert_allclose(C, A @ B, rtol=1e-3, atol=1e-3)

--- a/python/tests/cuda/test_local_storage_cuda.py
+++ b/python/tests/cuda/test_local_storage_cuda.py
@@ -562,3 +562,107 @@ def test_local_storage_fused_reduce(R, N, block, tmp_path):
 
     expected = (X - X.max(axis=1, keepdims=True)) / X.sum(axis=1, keepdims=True)
     np.testing.assert_allclose(Y, expected, rtol=1e-4, atol=1e-4)
+
+
+def _build_gemm_regtile(M, N, K, TY, TX, CY, CX):
+    """Thread-coarsened GEMM ``C = A@B`` where each thread owns a CY*CX tile of C.
+
+    Loop nest: jO(X_BLOCK) iO(Y_BLOCK) over the thread-tile grid, then k, then the
+    per-thread micro-tile loops iI,jI:
+        C[(iO*CY+iI), (jO*CX+jI)] += A[(iO*CY+iI), k] * B[k, (jO*CX+jI)]
+    Localizing C at the k loop turns the CY*CX accumulator into a per-thread
+    register tile (C_reg), accumulated across k and written back once.
+    """
+    f = Scalar(PrimitiveType.Float)
+    host = Pointer(f)
+    dev = Pointer(f, StorageType.NV_Generic())
+    i32 = Scalar(PrimitiveType.Int32)
+
+    b = StructuredSDFGBuilder("ls_gemm_regtile")
+    for nm in ("A", "B", "C"):
+        b.add_container(nm, host, is_argument=True)
+    for nm in ("__daisy_dev_A", "__daisy_dev_B", "__daisy_dev_C"):
+        b.add_container(nm, dev, is_argument=False)
+    for nm in ("jO", "iO", "k", "iI", "jI"):
+        b.add_container(nm, i32)
+
+    def off(hc, dc, dirn, life, size):
+        b.add_cuda_offloading_block(hc, dc, dirn, life, dev, size)
+
+    nbA = f"{M * K} * {FLOAT_BYTES}"
+    nbB = f"{K * N} * {FLOAT_BYTES}"
+    nbC = f"{M * N} * {FLOAT_BYTES}"
+    for dc, sz in (
+        ("__daisy_dev_A", nbA),
+        ("__daisy_dev_B", nbB),
+        ("__daisy_dev_C", nbC),
+    ):
+        off(dc, dc, DataTransferDirection.NONE, BufferLifecycle.ALLOC, sz)
+    off("A", "__daisy_dev_A", DataTransferDirection.H2D, BufferLifecycle.NO_CHANGE, nbA)
+    off("B", "__daisy_dev_B", DataTransferDirection.H2D, BufferLifecycle.NO_CHANGE, nbB)
+    off("C", "__daisy_dev_C", DataTransferDirection.H2D, BufferLifecycle.NO_CHANGE, nbC)
+
+    b.begin_map(
+        "jO", "0", str(N // CX), "1", ScheduleType.cuda_offload(TargetLevel.X_BLOCK, TX)
+    )
+    b.begin_map(
+        "iO", "0", str(M // CY), "1", ScheduleType.cuda_offload(TargetLevel.Y_BLOCK, TY)
+    )
+    k_loop = b.begin_for("k", "0", str(K), "1")
+    b.begin_for("iI", "0", str(CY), "1")
+    b.begin_for("jI", "0", str(CX), "1")
+    blk = b.add_block()
+    a = b.add_access(blk, "__daisy_dev_A")
+    bb = b.add_access(blk, "__daisy_dev_B")
+    c_in = b.add_access(blk, "__daisy_dev_C")
+    c_out = b.add_access(blk, "__daisy_dev_C")
+    t = b.add_tasklet(blk, TaskletCode.fp_fma, ["_in1", "_in2", "_in3"], ["_out"])
+    b.add_memlet(blk, a, "", t, "_in1", f"(iO*{CY} + iI)*{K} + k", dev)
+    b.add_memlet(blk, bb, "", t, "_in2", f"k*{N} + jO*{CX} + jI", dev)
+    b.add_memlet(blk, c_in, "", t, "_in3", f"(iO*{CY} + iI)*{N} + jO*{CX} + jI", dev)
+    b.add_memlet(blk, t, "_out", c_out, "", f"(iO*{CY} + iI)*{N} + jO*{CX} + jI", dev)
+    b.end_for()
+    b.end_for()
+    b.end_for()
+    b.end_map()
+    b.end_map()
+
+    off("C", "__daisy_dev_C", DataTransferDirection.D2H, BufferLifecycle.NO_CHANGE, nbC)
+    for dc in ("__daisy_dev_A", "__daisy_dev_B", "__daisy_dev_C"):
+        off(dc, dc, DataTransferDirection.NONE, BufferLifecycle.FREE, "0")
+
+    return b, k_loop, c_out
+
+
+@pytest.mark.parametrize(
+    "M,N,K,TY,TX,CY,CX",
+    [(8, 8, 4, 2, 2, 2, 2), (16, 16, 8, 4, 4, 2, 2), (8, 8, 3, 2, 2, 2, 2)],
+    ids=["8x8x4", "16x16x8", "8x8x3"],
+)
+def test_local_storage_register_tile_gemm(M, N, K, TY, TX, CY, CX, tmp_path):
+    builder, k_loop, c_out = _build_gemm_regtile(M, N, K, TY, TX, CY, CX)
+
+    am = AnalysisManager(builder)
+    xform = LocalStorage(k_loop, c_out)
+    assert xform.can_be_applied(builder, am), "C register tile should apply"
+    xform.apply(builder, am)
+
+    sdfg = builder.move()
+    sdfg.validate()
+    output_dir = tmp_path / f"gemm_{M}x{N}x{K}"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    lib_path = sdfg._compile(str(output_dir), "cuda")
+
+    generated = "\n".join(p.read_text() for p in output_dir.rglob("*.cu"))
+    assert "__daisy_local_storage" in generated, "C register tile not emitted"
+
+    compiled = CompiledSDFG(lib_path, sdfg)
+
+    rng = np.random.default_rng(0)
+    A = rng.standard_normal((M, K)).astype(np.float32)
+    B = rng.standard_normal((K, N)).astype(np.float32)
+    C = np.zeros((M, N), dtype=np.float32)
+
+    compiled(A.reshape(-1), B.reshape(-1), C.reshape(-1))
+
+    np.testing.assert_allclose(C, A @ B, rtol=1e-3, atol=1e-3)

--- a/python/tests/cuda/test_local_storage_cuda.py
+++ b/python/tests/cuda/test_local_storage_cuda.py
@@ -301,3 +301,106 @@ def test_local_storage_cooperative_mixed(N, M, K, bm, bn, tmp_path):
     # Each row i of C is the row sum of A[i, :], broadcast across the M columns.
     expected = np.broadcast_to(A.sum(axis=1)[:, None], (N, M))
     np.testing.assert_allclose(C, expected, rtol=1e-4, atol=1e-4)
+
+
+def _build_enclosing_reuse(R, N, block):
+    """Two sibling block loops over columns both read row X[row,:].
+
+    Pass 1: Y1[row,j] = X[row,j]. Pass 2: Y2[row,j] = X[row, N-1-j] (reversed).
+    Localizing X at the enclosing grid row-loop stages X[row,:] once into a
+    per-block shared row that both passes reuse; the reversed read proves the
+    whole row is resident and threads read one another's staged elements.
+    """
+    f = Scalar(PrimitiveType.Float)
+    host = Pointer(f)
+    dev = Pointer(f, StorageType.NV_Generic())
+    i32 = Scalar(PrimitiveType.Int32)
+
+    b = StructuredSDFGBuilder("ls_enclosing_cuda")
+    for nm in ("X", "Y1", "Y2"):
+        b.add_container(nm, host, is_argument=True)
+    for nm in ("__daisy_dev_X", "__daisy_dev_Y1", "__daisy_dev_Y2"):
+        b.add_container(nm, dev, is_argument=False)
+    b.add_container("row", i32)
+    b.add_container("j1", i32)
+    b.add_container("j2", i32)
+
+    def off(hc, dc, dirn, life, size):
+        b.add_cuda_offloading_block(hc, dc, dirn, life, dev, size)
+
+    nb = f"{R} * {N} * {FLOAT_BYTES}"
+    for nm in ("__daisy_dev_X", "__daisy_dev_Y1", "__daisy_dev_Y2"):
+        off(nm, nm, DataTransferDirection.NONE, BufferLifecycle.ALLOC, nb)
+    off("X", "__daisy_dev_X", DataTransferDirection.H2D, BufferLifecycle.NO_CHANGE, nb)
+
+    row_map = b.begin_map(
+        "row", "0", str(R), "1", ScheduleType.cuda_offload(TargetLevel.X_GRID, 1)
+    )
+    b.begin_map(
+        "j1", "0", str(N), "1", ScheduleType.cuda_offload(TargetLevel.X_BLOCK, block)
+    )
+    blk1 = b.add_block()
+    x1 = b.add_access(blk1, "__daisy_dev_X")
+    y1 = b.add_access(blk1, "__daisy_dev_Y1")
+    t1 = b.add_tasklet(blk1, TaskletCode.assign, ["_in"], ["_out"])
+    b.add_memlet(blk1, x1, "", t1, "_in", f"row*{N} + j1", dev)
+    b.add_memlet(blk1, t1, "_out", y1, "", f"row*{N} + j1", dev)
+    b.end_map()
+    b.begin_map(
+        "j2", "0", str(N), "1", ScheduleType.cuda_offload(TargetLevel.X_BLOCK, block)
+    )
+    blk2 = b.add_block()
+    x2 = b.add_access(blk2, "__daisy_dev_X")
+    y2 = b.add_access(blk2, "__daisy_dev_Y2")
+    t2 = b.add_tasklet(blk2, TaskletCode.assign, ["_in"], ["_out"])
+    b.add_memlet(blk2, x2, "", t2, "_in", f"row*{N} + ({N} - 1 - j2)", dev)
+    b.add_memlet(blk2, t2, "_out", y2, "", f"row*{N} + j2", dev)
+    b.end_map()
+    b.end_map()
+
+    for host_nm, dev_nm in (("Y1", "__daisy_dev_Y1"), ("Y2", "__daisy_dev_Y2")):
+        off(host_nm, dev_nm, DataTransferDirection.D2H, BufferLifecycle.NO_CHANGE, nb)
+    for nm in ("__daisy_dev_X", "__daisy_dev_Y1", "__daisy_dev_Y2"):
+        off(nm, nm, DataTransferDirection.NONE, BufferLifecycle.FREE, "0")
+
+    return b, row_map, x1
+
+
+@pytest.mark.parametrize(
+    "R,N,block",
+    [(4, 32, 32), (3, 50, 32), (5, 17, 16)],
+    ids=["4x32x32", "3x50x32", "5x17x16"],
+)
+def test_local_storage_enclosing_reuse(R, N, block, tmp_path):
+    builder, row_map, x1 = _build_enclosing_reuse(R, N, block)
+
+    am = AnalysisManager(builder)
+    xform = LocalStorage(row_map, x1)
+    assert xform.can_be_applied(
+        builder, am
+    ), "enclosing-scope cooperative staging should apply"
+    xform.apply(builder, am)
+    # Hoist the staging barrier's boundary guard so ragged blocks don't deadlock.
+    SyncConditionPropagation().run(builder, am)
+
+    sdfg = builder.move()
+    sdfg.validate()
+    output_dir = tmp_path / f"enc_{R}x{N}x{block}"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    lib_path = sdfg._compile(str(output_dir), "cuda")
+
+    generated = "\n".join(p.read_text() for p in output_dir.rglob("*.cu"))
+    assert "__shared__" in generated, "shared row buffer not emitted"
+    assert "__syncthreads" in generated, "staging barrier not emitted"
+
+    compiled = CompiledSDFG(lib_path, sdfg)
+
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((R, N)).astype(np.float32)
+    Y1 = np.zeros((R, N), dtype=np.float32)
+    Y2 = np.zeros((R, N), dtype=np.float32)
+
+    compiled(X.reshape(-1), Y1.reshape(-1), Y2.reshape(-1))
+
+    np.testing.assert_allclose(Y1, X, rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(Y2, X[:, ::-1], rtol=1e-6, atol=1e-6)

--- a/python/tests/cuda/test_local_storage_cuda.py
+++ b/python/tests/cuda/test_local_storage_cuda.py
@@ -20,6 +20,7 @@ import pytest
 from docc.sdfg import (
     AnalysisManager,
     BufferLifecycle,
+    CMathFunction,
     DataTransferDirection,
     LocalStorage,
     Pointer,
@@ -404,3 +405,160 @@ def test_local_storage_enclosing_reuse(R, N, block, tmp_path):
 
     np.testing.assert_allclose(Y1, X, rtol=1e-6, atol=1e-6)
     np.testing.assert_allclose(Y2, X[:, ::-1], rtol=1e-6, atol=1e-6)
+
+
+def _build_fused_reduce(R, N, block):
+    """Fused per-row normalize sharing one staged row across two reductions.
+
+    map row: stage X[row,:] -> buf; reduce-max -> m; barrier; reduce-sum -> s;
+    barrier; Y[row,j] = (buf[j] - m[row]) / s[row]. LocalStorage stages X so the
+    two reduces and the normalize all read the one shared row (X loaded once).
+    Reference: Y = (X - rowmax) / rowsum.
+    """
+    f = Scalar(PrimitiveType.Float)
+    host = Pointer(f)
+    dev = Pointer(f, StorageType.NV_Generic())
+    i32 = Scalar(PrimitiveType.Int32)
+
+    b = StructuredSDFGBuilder("ls_fused_cuda")
+    for nm in ("X", "Y", "m", "s"):
+        b.add_container(nm, host, is_argument=True)
+    for nm in ("__daisy_dev_X", "__daisy_dev_Y", "__daisy_dev_m", "__daisy_dev_s"):
+        b.add_container(nm, dev, is_argument=False)
+    b.add_container("tmp", dev, is_argument=False)  # per-thread scratch
+    for nm in ("row", "jr", "js", "jn"):
+        b.add_container(nm, i32)
+
+    def off(hc, dc, dirn, life, size):
+        b.add_cuda_offloading_block(hc, dc, dirn, life, dev, size)
+
+    nbX = f"{R} * {N} * {FLOAT_BYTES}"
+    nbm = f"{R} * {FLOAT_BYTES}"
+    for dc, sz in (
+        ("__daisy_dev_X", nbX),
+        ("__daisy_dev_Y", nbX),
+        ("__daisy_dev_m", nbm),
+        ("__daisy_dev_s", nbm),
+        ("tmp", str(FLOAT_BYTES)),
+    ):
+        off(dc, dc, DataTransferDirection.NONE, BufferLifecycle.ALLOC, sz)
+    off("X", "__daisy_dev_X", DataTransferDirection.H2D, BufferLifecycle.NO_CHANGE, nbX)
+    off("m", "__daisy_dev_m", DataTransferDirection.H2D, BufferLifecycle.NO_CHANGE, nbm)
+    off("s", "__daisy_dev_s", DataTransferDirection.H2D, BufferLifecycle.NO_CHANGE, nbm)
+
+    row_map = b.begin_map(
+        "row", "0", str(R), "1", ScheduleType.cuda_offload(TargetLevel.X_GRID, 1)
+    )
+
+    b.begin_reduce(
+        "jr",
+        "0",
+        str(N),
+        "1",
+        [("max", "__daisy_dev_m")],
+        ScheduleType.cuda_offload(TargetLevel.X_BLOCK, block),
+    )
+    rb = b.add_block()
+    mi = b.add_access(rb, "__daisy_dev_m")
+    xr = b.add_access(rb, "__daisy_dev_X")
+    mo = b.add_access(rb, "__daisy_dev_m")
+    mx = b.add_cmath(rb, CMathFunction.fmax, PrimitiveType.Float)
+    b.add_memlet(rb, mi, "", mx, "_in1", "row", dev)
+    b.add_memlet(rb, xr, "", mx, "_in2", f"row*{N} + jr", dev)
+    b.add_memlet(rb, mx, "_out", mo, "", "row", dev)
+    b.end_reduce()
+
+    b.add_barrier_local_block()
+
+    b.begin_reduce(
+        "js",
+        "0",
+        str(N),
+        "1",
+        [("add", "__daisy_dev_s")],
+        ScheduleType.cuda_offload(TargetLevel.X_BLOCK, block),
+    )
+    sb = b.add_block()
+    si = b.add_access(sb, "__daisy_dev_s")
+    xs = b.add_access(sb, "__daisy_dev_X")
+    so = b.add_access(sb, "__daisy_dev_s")
+    at = b.add_tasklet(sb, TaskletCode.fp_add, ["_in1", "_in2"], ["_out"])
+    b.add_memlet(sb, si, "", at, "_in1", "row", dev)
+    b.add_memlet(sb, xs, "", at, "_in2", f"row*{N} + js", dev)
+    b.add_memlet(sb, at, "_out", so, "", "row", dev)
+    b.end_reduce()
+
+    b.add_barrier_local_block()
+
+    b.begin_map(
+        "jn", "0", str(N), "1", ScheduleType.cuda_offload(TargetLevel.X_BLOCK, block)
+    )
+    nb = b.add_block()
+    xn = b.add_access(nb, "__daisy_dev_X")
+    mn = b.add_access(nb, "__daisy_dev_m")
+    tmp_o = b.add_access(nb, "tmp")
+    sub = b.add_tasklet(nb, TaskletCode.fp_sub, ["_in1", "_in2"], ["_out"])
+    b.add_memlet(nb, xn, "", sub, "_in1", f"row*{N} + jn", dev)
+    b.add_memlet(nb, mn, "", sub, "_in2", "row", dev)
+    b.add_memlet(nb, sub, "_out", tmp_o, "", "0", dev)
+    tmp_i = b.add_access(nb, "tmp")
+    sn = b.add_access(nb, "__daisy_dev_s")
+    yn = b.add_access(nb, "__daisy_dev_Y")
+    div = b.add_tasklet(nb, TaskletCode.fp_div, ["_in1", "_in2"], ["_out"])
+    b.add_memlet(nb, tmp_i, "", div, "_in1", "0", dev)
+    b.add_memlet(nb, sn, "", div, "_in2", "row", dev)
+    b.add_memlet(nb, div, "_out", yn, "", f"row*{N} + jn", dev)
+    b.end_map()
+
+    b.end_map()
+
+    off("Y", "__daisy_dev_Y", DataTransferDirection.D2H, BufferLifecycle.NO_CHANGE, nbX)
+    for dc in (
+        "__daisy_dev_X",
+        "__daisy_dev_Y",
+        "__daisy_dev_m",
+        "__daisy_dev_s",
+        "tmp",
+    ):
+        off(dc, dc, DataTransferDirection.NONE, BufferLifecycle.FREE, "0")
+
+    return b, row_map, xr
+
+
+@pytest.mark.parametrize(
+    "R,N,block",
+    [(4, 32, 32), (3, 50, 32), (5, 17, 16)],
+    ids=["4x32x32", "3x50x32", "5x17x16"],
+)
+def test_local_storage_fused_reduce(R, N, block, tmp_path):
+    builder, row_map, xr = _build_fused_reduce(R, N, block)
+
+    am = AnalysisManager(builder)
+    xform = LocalStorage(row_map, xr)
+    assert xform.can_be_applied(builder, am), "fused reduce staging should apply"
+    xform.apply(builder, am)
+    SyncConditionPropagation().run(builder, am)
+
+    sdfg = builder.move()
+    sdfg.validate()
+    output_dir = tmp_path / f"fused_{R}x{N}x{block}"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    lib_path = sdfg._compile(str(output_dir), "cuda")
+
+    generated = "\n".join(p.read_text() for p in output_dir.rglob("*.cu"))
+    # One staged row buffer, reused by both reduces and the normalize.
+    assert "__daisy_local_storage" in generated, "staged row buffer not emitted"
+    assert "__syncthreads" in generated, "barriers not emitted"
+
+    compiled = CompiledSDFG(lib_path, sdfg)
+
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((R, N)).astype(np.float32)
+    Y = np.zeros((R, N), dtype=np.float32)
+    m = np.full(R, -np.inf, dtype=np.float32)
+    s = np.zeros(R, dtype=np.float32)
+
+    compiled(X.reshape(-1), Y.reshape(-1), m, s)
+
+    expected = (X - X.max(axis=1, keepdims=True)) / X.sum(axis=1, keepdims=True)
+    np.testing.assert_allclose(Y, expected, rtol=1e-4, atol=1e-4)

--- a/python/tests/sdfg/transformations/test_local_storage.py
+++ b/python/tests/sdfg/transformations/test_local_storage.py
@@ -375,3 +375,75 @@ def test_local_storage_omp_cooperative_rejected():
     assert not xform.can_be_applied(
         builder, analysis_manager
     ), "cooperative tile across an OMP-parallel dim must be rejected"
+
+
+# ---------------------------------------------------------------------------
+# Reduction-accumulator privatization (gemv-style): a *sequential* Reduce over j
+# accumulates y[iO*CY + iI] for a per-iO block of CY outputs. Localizing y at the
+# Reduce loads the block once, accumulates in a private buffer across j, writes
+# back once, and retargets the Reduce descriptor to the buffer. A correct result
+# validates the copy-in/out + the reduction-container retarget end to end.
+#   y[iO*CY + iI] = sum_{j=0}^{K-1} A[(iO*CY+iI)*K + j] * x[j]
+# ---------------------------------------------------------------------------
+
+
+def _build_reduce_accumulator(K, CY):
+    builder = StructuredSDFGBuilder("ls_reduce_acc")
+    builder.add_container("R", U, is_argument=True)
+    builder.add_container("A", PF, is_argument=True)
+    builder.add_container("x", PF, is_argument=True)
+    builder.add_container("y", PF, is_argument=True)
+    builder.add_container("iO", U)
+    builder.add_container("j", U)
+    builder.add_container("iI", U)
+
+    builder.begin_for("iO", "0", "R", "1")
+    reduce = builder.begin_reduce("j", "0", str(K), "1", [("add", "y")])
+    builder.begin_for("iI", "0", str(CY), "1")
+    block = builder.add_block()
+    a_in = builder.add_access(block, "A")
+    x_in = builder.add_access(block, "x")
+    y_in = builder.add_access(block, "y")
+    y_out = builder.add_access(block, "y")
+    t = builder.add_tasklet(
+        block, TaskletCode.fp_fma, ["_in1", "_in2", "_in3"], ["_out"]
+    )
+    m = f"(iO*{CY} + iI)"
+    builder.add_memlet(block, a_in, "", t, "_in1", subset=f"{m}*{K} + j", type=PF)
+    builder.add_memlet(block, x_in, "", t, "_in2", subset="j", type=PF)
+    builder.add_memlet(block, y_in, "", t, "_in3", subset=m, type=PF)
+    builder.add_memlet(block, t, "_out", y_out, "", subset=m, type=PF)
+    builder.end_for()  # iI
+    builder.end_reduce()  # j
+    builder.end_for()  # iO
+
+    return builder, reduce, y_out
+
+
+@pytest.mark.parametrize(
+    "R,K,CY", [(4, 8, 2), (1, 5, 4), (3, 3, 2)], ids=["4x8x2", "1x5x4", "3x3x2"]
+)
+def test_local_storage_reduction_accumulator(R, K, CY, tmp_path):
+    builder, reduce, y_out = _build_reduce_accumulator(K, CY)
+    analysis_manager = AnalysisManager(builder)
+    xform = LocalStorage(reduce, y_out)
+    assert xform.can_be_applied(
+        builder, analysis_manager
+    ), "sequential reduction accumulator should be localizable"
+    xform.apply(builder, analysis_manager)
+
+    sdfg = builder.move()
+    output_dir = tmp_path / f"reduce_{R}x{K}x{CY}"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    lib_path = sdfg._compile(str(output_dir), "sequential")
+    compiled = CompiledSDFG(lib_path, sdfg)
+
+    rng = np.random.default_rng(7)
+    M = R * CY
+    A = rng.standard_normal((M, K)).astype(np.float32)
+    x = rng.standard_normal((K,)).astype(np.float32)
+    y = np.zeros((M,), dtype=np.float32)
+
+    compiled(R, A.reshape(-1), x, y)
+
+    np.testing.assert_allclose(y, A @ x, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill out this template to help reviewers
understand your changes. Remove sections that are not relevant.
-->

## Description
ReduceDispatcher currently creates its own buffers during codegen. This PR extends the dispatcher to respect name-matching shared memory containers that already exist in the SDFG. With this, LocalStorage can create shared buffers for kernels with multiple reductions. Furthermore, this PR generalizes the target-level matching strategy of the dispatcher to determine the partial result storage type with an explicit property on the schedule, so transformations can decide.

## Related Issues
<!-- Link issues this PR closes or relates to, e.g. "Closes #123" -->
- Closes #

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal change (no functional change)
- [ ] Documentation update

## Quality Checklist
*Please ensure the following are completed before requesting review:*

* [ ] Runtime-compatible (no externally visible existing method has its parameters changed, was deleted or has its exception behavior changed)
* [ ] Compile-time compatible (new arguments & properties added have default values, but users need to recompile against the new version to work)

IR:
* [ ] Introduces new types into the SDFG IR
* [ ]  Changed / added properties on SDFG IR Elements (LibraryNodes, ControlFlowNodes DataFlowNodes etc.)
  *  [ ] New / modified types have serialization / deserialization support
  *  [ ] Deserialization is backward compatible (new serialization can deserialize old format and represent it in the new format if applicable)
  *  [ ] Serialized format is backward compatible (previous deserializer can read new serialized format without incorrectness (just lacking additional guarantees that are optional or did not exist before)
  *  [ ] Serializer has an option to emit the previous format

### Unit Tests
- [ ] New unit tests have been added for the changes.
- [ ] Existing unit tests pass locally.
- [ ] Edge cases and error paths are covered.

### Integration Tests
- [ ] New integration tests have been added (or existing ones updated).
- [ ] Integration tests pass locally.
- [ ] Interactions with other components/services are verified.

### Documentation
- [ ] Public APIs, options, and behavior changes are documented.
- [ ] README / docs site / inline comments updated where applicable.
- [ ] Changelog / release notes updated (if applicable).

### Test Coverage
- [ ] Test coverage has not decreased as a result of this change.
- [ ] Coverage report reviewed and acceptable.
- [ ] Critical / new code paths are covered.

## How Has This Been Tested?
Describe the tests you ran to verify your changes and provide instructions to reproduce.
Include relevant details for your test configuration (OS, Python/LLVM/Docc version, hardware/target).

## Additional Context
Add any other context about the PR here (design decisions, trade-offs, follow-ups).
