### PR TITLE
Async Kernel Runtime capture for ROCm & CUDA in aggregate mode

### DIFF
--- a/rtl/include/daisy_rtl/daisy_rtl.h
+++ b/rtl/include/daisy_rtl/daisy_rtl.h
@@ -101,6 +101,9 @@ void __daisy_instrumentation_stop(void);
 // Query whether measurement is currently enabled (true by default).
 bool __daisy_instrumentation_is_enabled(void);
 
+// Called at end of instrumented function to do any cleanup or post processing before handles and libraries might destr
+void __daisy_instrumentation_finalize_all(void);
+
 typedef struct __daisy_capture __daisy_capture_t;
 
 __daisy_capture_t* __daisy_capture_init(const char* name, const char* base_dir);

--- a/rtl/src/instrumentation.cpp
+++ b/rtl/src/instrumentation.cpp
@@ -44,6 +44,16 @@ static inline pid_t gettid() { return syscall(SYS_gettid); }
 
 #define REGION_CACHE_SIZE 10
 
+#ifndef DEBUG_RTL
+#define DEBUG_PRINTLN(...) ((void) 0)
+#else
+#define DEBUG_PRINTLN(...)                     \
+    do {                                       \
+        std::cerr << __VA_ARGS__ << std::endl; \
+    } while (0)
+#endif
+
+
 // -----------------------------------------------------------------------------
 //  Dynamic PAPI loading – we avoid a hard dependency on the library at link time
 // -----------------------------------------------------------------------------
@@ -200,6 +210,9 @@ private:
         cuEventDestroy_ = reinterpret_cast<int (*)(void*)>(dlsym(cudart_handle_, "cudaEventDestroy"));
         cuda_events_available_ = cuEventCreate_ && cuEventRecord_ && cuEventSynchronize_ && cuEventElapsedTime_ &&
                                  cuEventDestroy_;
+        if (!cuda_events_available_) {
+            std::cerr << "[daisy-rtl] Failed to load CUDA event functions from libcudart.so\n";
+        }
         return cuda_events_available_;
     }
 
@@ -237,15 +250,30 @@ private:
     // elapsed times into its aggregate runtime stats. Events are returned to the
     // pool for reuse. Called from the stats accessors (once per batch).
     void resolve_cuda_pending(DaisyRegion& region) {
-        for (auto& [start, stop] : region.cuda_pending) {
-            cuEventSynchronize_(stop);
-            float ms = 0.0f;
-            cuEventElapsedTime_(&ms, start, stop);
-            accumulate_runtime(region, static_cast<long long>(static_cast<double>(ms) * 1.0e6));
-            cuda_event_pool_.push_back(start);
-            cuda_event_pool_.push_back(stop);
+        if (!region.cuda_pending.empty()) {
+            for (auto& [start, stop] : region.cuda_pending) {
+                cuEventSynchronize_(stop);
+                float ms = 0.0f;
+                cuEventElapsedTime_(&ms, start, stop);
+                DEBUG_PRINTLN(
+                    "[daisy-rtl] CUDA region " << region.metadata.region_uuid << " elapsed time: " << ms << " ms"
+                );
+                if (this->aggregate_events) {
+                    accumulate_runtime(region, static_cast<long long>(static_cast<double>(ms) * 1.0e6));
+                }
+                cuda_event_pool_.push_back(start);
+                cuda_event_pool_.push_back(stop);
+            }
+            region.cuda_pending.clear();
         }
-        region.cuda_pending.clear();
+    }
+
+    void post_process_region(DaisyRegion& region) { resolve_cuda_pending(region); }
+
+    void post_process_regions() {
+        for (auto& [region_id, region] : regions) {
+            post_process_region(region);
+        }
     }
 
     double ns_to_us(double ns) { return ns / 1000; }
@@ -640,6 +668,8 @@ public:
 
         this->region_name_to_id.clear();
 
+        post_process_regions();
+
         // Write output file
         FILE* f = std::fopen(this->output_file.c_str(), "w");
         if (!f) {
@@ -755,15 +785,17 @@ public:
                 }
                 if (region.event_set == __DAISY_EVENT_SET_CPU) {
                     for (const auto& ev : this->event_names_cpu) {
-                        if (_PAPI_add_named_event(region.papi_eventset, ev.c_str()) != 0) {
-                            std::fprintf(stderr, "[daisy-rtl] Could not add event %s.\n", ev.c_str());
+                        auto papi_result = _PAPI_add_named_event(region.papi_eventset, ev.c_str());
+                        if (papi_result != 0) {
+                            std::fprintf(stderr, "[daisy-rtl] Could not add event %s (%d).\n", ev.c_str(), papi_result);
                             exit(EXIT_FAILURE);
                         }
                     }
                 } else if (region.event_set == __DAISY_EVENT_SET_CUDA) {
                     for (const auto& ev : this->event_names_cuda) {
-                        if (_PAPI_add_named_event(region.papi_eventset, ev.c_str()) != 0) {
-                            std::fprintf(stderr, "[daisy-rtl] Could not add event %s.\n", ev.c_str());
+                        auto papi_result = _PAPI_add_named_event(region.papi_eventset, ev.c_str());
+                        if (papi_result != 0) {
+                            std::fprintf(stderr, "[daisy-rtl] Could not add event %s (%d).\n", ev.c_str(), papi_result);
                             exit(EXIT_FAILURE);
                         }
                     }
@@ -787,15 +819,17 @@ public:
             }
             if (region.event_set == __DAISY_EVENT_SET_CPU) {
                 for (const auto& ev : this->event_names_cpu) {
-                    if (_PAPI_add_named_event(region.papi_eventset, ev.c_str()) != 0) {
-                        std::fprintf(stderr, "[daisy-rtl] Could not add event %s.\n", ev.c_str());
+                    auto papi_result = _PAPI_add_named_event(region.papi_eventset, ev.c_str());
+                    if (papi_result != 0) {
+                        std::fprintf(stderr, "[daisy-rtl] Could not add event %s (%d).\n", ev.c_str(), papi_result);
                         exit(EXIT_FAILURE);
                     }
                 }
             } else if (region.event_set == __DAISY_EVENT_SET_CUDA) {
                 for (const auto& ev : this->event_names_cuda) {
-                    if (_PAPI_add_named_event(region.papi_eventset, ev.c_str()) != 0) {
-                        std::fprintf(stderr, "[daisy-rtl] Could not add event %s.\n", ev.c_str());
+                    auto papi_result = _PAPI_add_named_event(region.papi_eventset, ev.c_str());
+                    if (papi_result != 0) {
+                        std::fprintf(stderr, "[daisy-rtl] Could not add event %s (%d).\n", ev.c_str(), papi_result);
                         exit(EXIT_FAILURE);
                     }
                 }
@@ -854,6 +888,7 @@ public:
             region.last_cuda_start = acquire_cuda_event();
             if (region.last_cuda_start) {
                 cuEventRecord_(region.last_cuda_start, nullptr);
+                DEBUG_PRINTLN("[daisy-rtl] CUDA region " << region.metadata.region_uuid << " start event recorded.");
             }
         }
     }
@@ -881,8 +916,13 @@ public:
             void* stop = acquire_cuda_event();
             if (stop) {
                 cuEventRecord_(stop, nullptr);
+                DEBUG_PRINTLN("[daisy-rtl] CUDA region " << region.metadata.region_uuid << " stop event recorded.");
                 region.cuda_pending.emplace_back(region.last_cuda_start, stop);
             } else {
+                DEBUG_PRINTLN(
+                    "[daisy-rtl] CUDA region " << region.metadata.region_uuid
+                                               << " stop event failed to acquire; dropping start event."
+                );
                 cuda_event_pool_.push_back(region.last_cuda_start);
             }
             region.last_cuda_start = nullptr;

--- a/rtl/src/instrumentation.cpp
+++ b/rtl/src/instrumentation.cpp
@@ -125,6 +125,13 @@ struct DaisyRegion {
     std::unordered_map<std::string, double> static_counters_variance;
     std::unordered_map<std::string, double> static_counters_min;
     std::unordered_map<std::string, double> static_counters_max;
+
+    // CUDA-event timing: kernels are timed with cudaEvents recorded on the stream
+    // (no per-launch host sync), so back-to-back launches stay async and the GPU
+    // boosts. `last_cuda_start` holds the enter event; each exit pushes a
+    // (start, stop) pair, resolved (synchronize + elapsed) lazily at stats time.
+    void* last_cuda_start = nullptr;
+    std::vector<std::pair<void*, void*>> cuda_pending;
 };
 
 struct JsSafeDouble {
@@ -165,6 +172,81 @@ private:
     std::vector<std::string> event_names_cuda;
 
     std::mutex mutex;
+
+    // CUDA event API loaded lazily via dlopen (no hard cudart link dependency).
+    // When available, CUDA regions are timed with events instead of a host clock
+    // + per-launch cudaDeviceSynchronize, so launches stay async and clocks boost.
+    bool cuda_events_tried_ = false;
+    bool cuda_events_available_ = false;
+    void* cudart_handle_ = nullptr;
+    int (*cuEventCreate_)(void**) = nullptr;
+    int (*cuEventRecord_)(void*, void*) = nullptr;
+    int (*cuEventSynchronize_)(void*) = nullptr;
+    int (*cuEventElapsedTime_)(float*, void*, void*) = nullptr;
+    int (*cuEventDestroy_)(void*) = nullptr;
+    std::vector<void*> cuda_event_pool_;
+
+    bool ensure_cuda_events() {
+        if (cuda_events_tried_) return cuda_events_available_;
+        cuda_events_tried_ = true;
+        cudart_handle_ = dlopen("libcudart.so", RTLD_NOW | RTLD_GLOBAL);
+        if (!cudart_handle_) cudart_handle_ = dlopen("libcudart.so.12", RTLD_NOW | RTLD_GLOBAL);
+        if (!cudart_handle_) return false;
+        cuEventCreate_ = reinterpret_cast<int (*)(void**)>(dlsym(cudart_handle_, "cudaEventCreate"));
+        cuEventRecord_ = reinterpret_cast<int (*)(void*, void*)>(dlsym(cudart_handle_, "cudaEventRecord"));
+        cuEventSynchronize_ = reinterpret_cast<int (*)(void*)>(dlsym(cudart_handle_, "cudaEventSynchronize"));
+        cuEventElapsedTime_ =
+            reinterpret_cast<int (*)(float*, void*, void*)>(dlsym(cudart_handle_, "cudaEventElapsedTime"));
+        cuEventDestroy_ = reinterpret_cast<int (*)(void*)>(dlsym(cudart_handle_, "cudaEventDestroy"));
+        cuda_events_available_ = cuEventCreate_ && cuEventRecord_ && cuEventSynchronize_ && cuEventElapsedTime_ &&
+                                 cuEventDestroy_;
+        return cuda_events_available_;
+    }
+
+    void* acquire_cuda_event() {
+        if (!cuda_event_pool_.empty()) {
+            void* e = cuda_event_pool_.back();
+            cuda_event_pool_.pop_back();
+            return e;
+        }
+        void* e = nullptr;
+        if (cuEventCreate_(&e) != 0) return nullptr;
+        return e;
+    }
+
+    // Accumulate one duration into a region's aggregate runtime stats (Welford).
+    static void accumulate_runtime(DaisyRegion& region, long long duration_ns) {
+        if (region.runtime_n == 0) {
+            region.runtime_n = 1;
+            region.runtime_mean = static_cast<double>(duration_ns);
+            region.runtime_variance = 0.0;
+            region.runtime_min = duration_ns;
+            region.runtime_max = duration_ns;
+        } else {
+            region.runtime_n += 1;
+            double delta1 = duration_ns - region.runtime_mean;
+            region.runtime_mean += delta1 / region.runtime_n;
+            double delta2 = duration_ns - region.runtime_mean;
+            region.runtime_variance += (delta1 * delta2 - region.runtime_variance) / region.runtime_n;
+            if (duration_ns < region.runtime_min) region.runtime_min = duration_ns;
+            if (duration_ns > region.runtime_max) region.runtime_max = duration_ns;
+        }
+    }
+
+    // Synchronize + read every pending CUDA-event pair for `region` and fold the
+    // elapsed times into its aggregate runtime stats. Events are returned to the
+    // pool for reuse. Called from the stats accessors (once per batch).
+    void resolve_cuda_pending(DaisyRegion& region) {
+        for (auto& [start, stop] : region.cuda_pending) {
+            cuEventSynchronize_(stop);
+            float ms = 0.0f;
+            cuEventElapsedTime_(&ms, start, stop);
+            accumulate_runtime(region, static_cast<long long>(static_cast<double>(ms) * 1.0e6));
+            cuda_event_pool_.push_back(start);
+            cuda_event_pool_.push_back(stop);
+        }
+        region.cuda_pending.clear();
+    }
 
     double ns_to_us(double ns) { return ns / 1000; }
 
@@ -765,6 +847,15 @@ public:
         } else {
             region.starts.push_back(start_ns);
         }
+
+        // CUDA regions: record a start event on the stream (async, no host sync)
+        // so back-to-back launches stay hot; the paired exit records the stop.
+        if (region.event_set == __DAISY_EVENT_SET_CUDA && ensure_cuda_events()) {
+            region.last_cuda_start = acquire_cuda_event();
+            if (region.last_cuda_start) {
+                cuEventRecord_(region.last_cuda_start, nullptr);
+            }
+        }
     }
 
     void exit_region(size_t region_id) {
@@ -782,6 +873,21 @@ public:
         }
 
         DaisyRegion& region = it->second;
+
+        // CUDA-event timing: record the stop event on the stream and defer the
+        // elapsed-time read to stats time. The host clock would only see the async
+        // launch, so skip it (and the PAPI-counter path, unused for pure timing).
+        if (region.event_set == __DAISY_EVENT_SET_CUDA && cuda_events_available_ && region.last_cuda_start) {
+            void* stop = acquire_cuda_event();
+            if (stop) {
+                cuEventRecord_(stop, nullptr);
+                region.cuda_pending.emplace_back(region.last_cuda_start, stop);
+            } else {
+                cuda_event_pool_.push_back(region.last_cuda_start);
+            }
+            region.last_cuda_start = nullptr;
+            return;
+        }
 
         // Save duration (before counters)
         long long end_ns = _PAPI_get_real_nsec();
@@ -1014,6 +1120,7 @@ public:
             return false;
         }
         DaisyRegion& region = it->second;
+        resolve_cuda_pending(region);
         if (region.runtime_n <= 0) {
             return false;
         }
@@ -1033,6 +1140,7 @@ public:
         bool any = false;
         for (auto& kv : regions) {
             DaisyRegion& region = kv.second;
+            resolve_cuda_pending(region);
             if (region.runtime_n <= 0) {
                 continue;
             }
@@ -1061,6 +1169,16 @@ public:
             region.first_start = 0;
             region.starts.clear();
             region.durations.clear();
+
+            // Discard any pending CUDA events (e.g. the warmup launch) so their
+            // timing is dropped consistently with the runtime stats above; the
+            // events are recycled into the pool.
+            for (auto& [start, stop] : region.cuda_pending) {
+                cuda_event_pool_.push_back(start);
+                cuda_event_pool_.push_back(stop);
+            }
+            region.cuda_pending.clear();
+            region.last_cuda_start = nullptr;
 
             // Hardware-counter aggregates, cleared so all metrics drop the
             // warmup sample consistently with the runtime stats above.

--- a/rtl/src/instrumentation.cpp
+++ b/rtl/src/instrumentation.cpp
@@ -203,6 +203,7 @@ private:
 
     bool aggregate_events = false;
     bool papi_available = false;
+    bool no_async_event_capture = false;
     std::string output_file;
 
     // Global measurement switch. When false, enter/exit/metric calls are no-ops
@@ -319,6 +320,8 @@ private:
                     );
                     if (this->aggregate_events) {
                         accumulate_runtime(region, static_cast<long long>(static_cast<double>(ms) * 1.0e6));
+                    } else {
+                        region.durations.push_back(static_cast<long long>(static_cast<double>(ms) * 1.0e6));
                     }
                 }
                 api.event_pool.push_back(start);
@@ -697,6 +700,13 @@ public:
             split_string(env_events_cuda, this->event_names_cuda);
             verify_events_exist(this->event_names_cuda);
         }
+
+        const char* env_events_async_capture = std::getenv("__DAISY_INSTRUMENTATION_ASYNC_CAPTURE");
+        if (env_events_async_capture) {
+            if (std::strcmp(env_events_async_capture, "0") == 0) {
+                this->no_async_event_capture = true;
+            }
+        }
     }
 
     ~DaisyInstrumentationState() {
@@ -820,6 +830,9 @@ public:
     }
 
     EventCaptureType decide_event_capture(enum __daisy_event_set event_set, const __daisy_metadata* metadata) {
+        if (this->no_async_event_capture || !this->aggregate_events) {
+            return EventCaptureType::NONE;
+        }
         if (event_set == __DAISY_EVENT_SET_CUDA) {
             if (metadata->target_type && std::strcmp(metadata->target_type, "CUDA") == 0) {
                 if (ensure_cuda_events()) {
@@ -910,6 +923,8 @@ public:
                     if (papi_result != 0) {
                         std::fprintf(stderr, "[daisy-rtl] Could not add event %s (%d).\n", ev.c_str(), papi_result);
                         exit(EXIT_FAILURE);
+                    } else {
+                        DEBUG_PRINTLN("[daisy-rtl] Added PAPI event " << ev << " to region " << metadata->region_uuid);
                     }
                 }
             }
@@ -947,20 +962,12 @@ public:
         } else if (region.event_set == __DAISY_EVENT_SET_CUDA && this->event_names_cuda.size() > 0) {
             std::vector<long long> counts(this->event_names_cuda.size(), 0);
             _PAPI_read(region.papi_eventset, counts.data());
+            DEBUG_PRINTLN("[daisy-rtl] Read CUDA event counts: " << counts.size());
             region.last_counts = counts;
         }
 
-        // Save start time
-        long long start_ns = _PAPI_get_real_nsec();
-        if (this->aggregate_events) {
-            if (region.first_start == 0) {
-                region.first_start = start_ns;
-            }
-            region.last_start = start_ns;
-        } else {
-            region.starts.push_back(start_ns);
-        }
 
+        bool async_capture = false;
         // CUDA regions: record a start event on the stream (async, no host sync)
         // so back-to-back launches stay hot; the paired exit records the stop.
         if (region.event_capture_type != EventCaptureType::NONE) {
@@ -972,6 +979,20 @@ public:
                     std::cerr << "[daisy-rtl] GPU eventRecord start failed with " << res << "\n";
                 }
                 DEBUG_PRINTLN("[daisy-rtl] GPU region " << region.metadata.region_uuid << " start event recorded.");
+                async_capture = true;
+            }
+        }
+
+        if (!async_capture) {
+            // Save start time
+            long long start_ns = _PAPI_get_real_nsec();
+            if (this->aggregate_events) {
+                if (region.first_start == 0) {
+                    region.first_start = start_ns;
+                }
+                region.last_start = start_ns;
+            } else {
+                region.starts.push_back(start_ns);
             }
         }
     }
@@ -1013,33 +1034,32 @@ public:
                 api.event_pool.push_back(region.last_start_event);
             }
             region.last_start_event = nullptr;
-            return;
-        }
-
-        // Save duration (before counters)
-        long long end_ns = _PAPI_get_real_nsec();
-        if (this->aggregate_events) {
-            long long duration_ns = end_ns - region.last_start;
-
-            // Update aggregated runtime stats
-            if (region.runtime_n == 0) {
-                region.runtime_n = 1;
-                region.runtime_mean = static_cast<double>(duration_ns);
-                region.runtime_variance = 0.0;
-                region.runtime_min = duration_ns;
-                region.runtime_max = duration_ns;
-            } else {
-                region.runtime_n += 1;
-                double delta1 = duration_ns - region.runtime_mean;
-                region.runtime_mean += delta1 / region.runtime_n;
-                double delta2 = duration_ns - region.runtime_mean;
-                region.runtime_variance += (delta1 * delta2 - region.runtime_variance) / region.runtime_n;
-                if (duration_ns < region.runtime_min) region.runtime_min = duration_ns;
-                if (duration_ns > region.runtime_max) region.runtime_max = duration_ns;
-            }
         } else {
-            long long duration_ns = end_ns - region.starts.back();
-            region.durations.push_back(duration_ns);
+            // Save duration (before counters)
+            long long end_ns = _PAPI_get_real_nsec();
+            if (this->aggregate_events) {
+                long long duration_ns = end_ns - region.last_start;
+
+                // Update aggregated runtime stats
+                if (region.runtime_n == 0) {
+                    region.runtime_n = 1;
+                    region.runtime_mean = static_cast<double>(duration_ns);
+                    region.runtime_variance = 0.0;
+                    region.runtime_min = duration_ns;
+                    region.runtime_max = duration_ns;
+                } else {
+                    region.runtime_n += 1;
+                    double delta1 = duration_ns - region.runtime_mean;
+                    region.runtime_mean += delta1 / region.runtime_n;
+                    double delta2 = duration_ns - region.runtime_mean;
+                    region.runtime_variance += (delta1 * delta2 - region.runtime_variance) / region.runtime_n;
+                    if (duration_ns < region.runtime_min) region.runtime_min = duration_ns;
+                    if (duration_ns > region.runtime_max) region.runtime_max = duration_ns;
+                }
+            } else {
+                long long duration_ns = end_ns - region.starts.back();
+                region.durations.push_back(duration_ns);
+            }
         }
 
         // Save end counters

--- a/rtl/src/instrumentation.cpp
+++ b/rtl/src/instrumentation.cpp
@@ -94,10 +94,13 @@ static void load_papi_symbols() {
 }
 } // namespace
 
+enum class EventCaptureType { NONE = 0, CUDA_EVT = 1, ROCM_EVT = 2 };
+
 struct DaisyRegion {
     __daisy_metadata metadata;
     enum __daisy_event_set event_set;
     int papi_eventset = -1;
+    EventCaptureType event_capture_type;
 
     // Temporary buffers
     std::vector<long long> last_counts;
@@ -140,8 +143,8 @@ struct DaisyRegion {
     // (no per-launch host sync), so back-to-back launches stay async and the GPU
     // boosts. `last_cuda_start` holds the enter event; each exit pushes a
     // (start, stop) pair, resolved (synchronize + elapsed) lazily at stats time.
-    void* last_cuda_start = nullptr;
-    std::vector<std::pair<void*, void*>> cuda_pending;
+    void* last_start_event = nullptr;
+    std::vector<std::pair<void*, void*>> pending_events;
 };
 
 struct JsSafeDouble {
@@ -157,6 +160,35 @@ static std::ostream& operator<<(std::ostream& os, JsSafeDouble val) {
     }
     return os;
 }
+
+// CUDA event API loaded lazily via dlopen (no hard cudart link dependency).
+// When available, CUDA regions are timed with events instead of a host clock
+// + per-launch cudaDeviceSynchronize, so launches stay async and clocks boost.
+struct GpuEventApi {
+    bool tried_loading = false;
+    bool loaded = false;
+    void* event_lib_handle = nullptr;
+    int (*eventCreate_)(void**) = nullptr;
+    int (*eventRecord_)(void*, void*) = nullptr;
+    int (*eventSynchronize_)(void*) = nullptr;
+    int (*eventElapsedTime_)(float*, void*, void*) = nullptr;
+    int (*eventDestroy_)(void*) = nullptr;
+    const char* (*errorString)(int) = nullptr;
+    const char* (*errorName)(int) = nullptr;
+
+    std::vector<void*> event_pool;
+
+    void* acquire_new_event() {
+        if (!event_pool.empty()) {
+            void* e = event_pool.back();
+            event_pool.pop_back();
+            return e;
+        }
+        void* e = nullptr;
+        if (eventCreate_(&e) != 0) return nullptr;
+        return e;
+    }
+};
 
 class DaisyInstrumentationState {
 private:
@@ -183,48 +215,67 @@ private:
 
     std::mutex mutex;
 
-    // CUDA event API loaded lazily via dlopen (no hard cudart link dependency).
-    // When available, CUDA regions are timed with events instead of a host clock
-    // + per-launch cudaDeviceSynchronize, so launches stay async and clocks boost.
-    bool cuda_events_tried_ = false;
-    bool cuda_events_available_ = false;
-    void* cudart_handle_ = nullptr;
-    int (*cuEventCreate_)(void**) = nullptr;
-    int (*cuEventRecord_)(void*, void*) = nullptr;
-    int (*cuEventSynchronize_)(void*) = nullptr;
-    int (*cuEventElapsedTime_)(float*, void*, void*) = nullptr;
-    int (*cuEventDestroy_)(void*) = nullptr;
-    std::vector<void*> cuda_event_pool_;
+    GpuEventApi cuda_events_;
+    GpuEventApi rocm_events_;
 
     bool ensure_cuda_events() {
-        if (cuda_events_tried_) return cuda_events_available_;
-        cuda_events_tried_ = true;
-        cudart_handle_ = dlopen("libcudart.so", RTLD_NOW | RTLD_GLOBAL);
-        if (!cudart_handle_) cudart_handle_ = dlopen("libcudart.so.12", RTLD_NOW | RTLD_GLOBAL);
-        if (!cudart_handle_) return false;
-        cuEventCreate_ = reinterpret_cast<int (*)(void**)>(dlsym(cudart_handle_, "cudaEventCreate"));
-        cuEventRecord_ = reinterpret_cast<int (*)(void*, void*)>(dlsym(cudart_handle_, "cudaEventRecord"));
-        cuEventSynchronize_ = reinterpret_cast<int (*)(void*)>(dlsym(cudart_handle_, "cudaEventSynchronize"));
-        cuEventElapsedTime_ =
-            reinterpret_cast<int (*)(float*, void*, void*)>(dlsym(cudart_handle_, "cudaEventElapsedTime"));
-        cuEventDestroy_ = reinterpret_cast<int (*)(void*)>(dlsym(cudart_handle_, "cudaEventDestroy"));
-        cuda_events_available_ = cuEventCreate_ && cuEventRecord_ && cuEventSynchronize_ && cuEventElapsedTime_ &&
-                                 cuEventDestroy_;
-        if (!cuda_events_available_) {
+        if (cuda_events_.tried_loading) return cuda_events_.loaded;
+        cuda_events_.tried_loading = true;
+        cuda_events_.event_lib_handle = dlopen("libcudart.so", RTLD_NOW | RTLD_GLOBAL);
+        if (!cuda_events_.event_lib_handle)
+            cuda_events_.event_lib_handle = dlopen("libcudart.so.12", RTLD_NOW | RTLD_GLOBAL);
+        if (!cuda_events_.event_lib_handle) return false;
+        cuda_events_.eventCreate_ =
+            reinterpret_cast<int (*)(void**)>(dlsym(cuda_events_.event_lib_handle, "cudaEventCreate"));
+        cuda_events_.eventRecord_ =
+            reinterpret_cast<int (*)(void*, void*)>(dlsym(cuda_events_.event_lib_handle, "cudaEventRecord"));
+        cuda_events_.eventSynchronize_ =
+            reinterpret_cast<int (*)(void*)>(dlsym(cuda_events_.event_lib_handle, "cudaEventSynchronize"));
+        cuda_events_.eventElapsedTime_ =
+            reinterpret_cast<int (*)(float*, void*, void*)>(dlsym(cuda_events_.event_lib_handle, "cudaEventElapsedTime")
+            );
+        cuda_events_.eventDestroy_ =
+            reinterpret_cast<int (*)(void*)>(dlsym(cuda_events_.event_lib_handle, "cudaEventDestroy"));
+        cuda_events_.errorString =
+            reinterpret_cast<const char* (*) (int)>(dlsym(cuda_events_.event_lib_handle, "cudaGetErrorString"));
+        cuda_events_.errorName =
+            reinterpret_cast<const char* (*) (int)>(dlsym(cuda_events_.event_lib_handle, "cudaGetErrorName"));
+        cuda_events_.loaded = cuda_events_.eventCreate_ && cuda_events_.eventRecord_ &&
+                              cuda_events_.eventSynchronize_ && cuda_events_.eventElapsedTime_ &&
+                              cuda_events_.eventDestroy_;
+        if (!cuda_events_.loaded) {
             std::cerr << "[daisy-rtl] Failed to load CUDA event functions from libcudart.so\n";
         }
-        return cuda_events_available_;
+        return cuda_events_.loaded;
     }
 
-    void* acquire_cuda_event() {
-        if (!cuda_event_pool_.empty()) {
-            void* e = cuda_event_pool_.back();
-            cuda_event_pool_.pop_back();
-            return e;
+    bool ensure_rocm_events() {
+        if (rocm_events_.tried_loading) return rocm_events_.loaded;
+        rocm_events_.tried_loading = true;
+        rocm_events_.event_lib_handle = dlopen("libamdhip64.so", RTLD_NOW | RTLD_GLOBAL);
+        if (!rocm_events_.event_lib_handle) return false;
+        rocm_events_.eventCreate_ =
+            reinterpret_cast<int (*)(void**)>(dlsym(rocm_events_.event_lib_handle, "hipEventCreate"));
+        rocm_events_.eventRecord_ =
+            reinterpret_cast<int (*)(void*, void*)>(dlsym(rocm_events_.event_lib_handle, "hipEventRecord"));
+        rocm_events_.eventSynchronize_ =
+            reinterpret_cast<int (*)(void*)>(dlsym(rocm_events_.event_lib_handle, "hipEventSynchronize"));
+        rocm_events_.eventElapsedTime_ =
+            reinterpret_cast<int (*)(float*, void*, void*)>(dlsym(rocm_events_.event_lib_handle, "hipEventElapsedTime")
+            );
+        rocm_events_.eventDestroy_ =
+            reinterpret_cast<int (*)(void*)>(dlsym(rocm_events_.event_lib_handle, "hipEventDestroy"));
+        rocm_events_.errorString =
+            reinterpret_cast<const char* (*) (int)>(dlsym(rocm_events_.event_lib_handle, "hipGetErrorString"));
+        rocm_events_.errorName =
+            reinterpret_cast<const char* (*) (int)>(dlsym(rocm_events_.event_lib_handle, "hipGetErrorName"));
+        rocm_events_.loaded = rocm_events_.eventCreate_ && rocm_events_.eventRecord_ &&
+                              rocm_events_.eventSynchronize_ && rocm_events_.eventElapsedTime_ &&
+                              rocm_events_.eventDestroy_;
+        if (!rocm_events_.loaded) {
+            std::cerr << "[daisy-rtl] Failed to load ROCM event functions from libamdhip64.so\n";
         }
-        void* e = nullptr;
-        if (cuEventCreate_(&e) != 0) return nullptr;
-        return e;
+        return rocm_events_.loaded;
     }
 
     // Accumulate one duration into a region's aggregate runtime stats (Welford).
@@ -249,32 +300,35 @@ private:
     // Synchronize + read every pending CUDA-event pair for `region` and fold the
     // elapsed times into its aggregate runtime stats. Events are returned to the
     // pool for reuse. Called from the stats accessors (once per batch).
-    void resolve_cuda_pending(DaisyRegion& region) {
-        if (!region.cuda_pending.empty()) {
-            for (auto& [start, stop] : region.cuda_pending) {
-                cuEventSynchronize_(stop);
-                float ms = 0.0f;
-                cuEventElapsedTime_(&ms, start, stop);
-                DEBUG_PRINTLN(
-                    "[daisy-rtl] CUDA region " << region.metadata.region_uuid << " elapsed time: " << ms << " ms"
-                );
-                if (this->aggregate_events) {
-                    accumulate_runtime(region, static_cast<long long>(static_cast<double>(ms) * 1.0e6));
+    void resolve_pending_events(DaisyRegion& region) {
+        if (!region.pending_events.empty()) {
+            auto& api = get_event_api(region.event_capture_type);
+            for (auto& [start, stop] : region.pending_events) {
+                auto res = api.eventSynchronize_(stop);
+                if (res != 0) {
+                    std::cerr << "[daisy-rtl] GPU event synchronization failed with " << res << "\n";
                 }
-                cuda_event_pool_.push_back(start);
-                cuda_event_pool_.push_back(stop);
+                float ms = 0.0f;
+                res = api.eventElapsedTime_(&ms, start, stop);
+                if (res != 0) {
+                    std::cerr << "[daisy-rtl] GPU eventElapsedTime failed with " << res << ": " << api.errorString(res)
+                              << "\n";
+                } else {
+                    DEBUG_PRINTLN(
+                        "[daisy-rtl] GPU region " << region.metadata.region_uuid << " elapsed time: " << ms << " ms"
+                    );
+                    if (this->aggregate_events) {
+                        accumulate_runtime(region, static_cast<long long>(static_cast<double>(ms) * 1.0e6));
+                    }
+                }
+                api.event_pool.push_back(start);
+                api.event_pool.push_back(stop);
             }
-            region.cuda_pending.clear();
+            region.pending_events.clear();
         }
     }
 
-    void post_process_region(DaisyRegion& region) { resolve_cuda_pending(region); }
-
-    void post_process_regions() {
-        for (auto& [region_id, region] : regions) {
-            post_process_region(region);
-        }
-    }
+    void post_process_region(DaisyRegion& region) { resolve_pending_events(region); }
 
     double ns_to_us(double ns) { return ns / 1000; }
 
@@ -668,7 +722,16 @@ public:
 
         this->region_name_to_id.clear();
 
-        post_process_regions();
+        for (auto& [region_id, region] : regions) {
+            if (!region.pending_events.empty()) {
+                std::fprintf(
+                    stderr,
+                    "[daisy-rtl] Region %s has unresolved pending events. Call process_async\n",
+                    region.metadata.region_uuid
+                );
+                exit(EXIT_FAILURE);
+            }
+        }
 
         // Write output file
         FILE* f = std::fopen(this->output_file.c_str(), "w");
@@ -756,6 +819,21 @@ public:
         }
     }
 
+    EventCaptureType decide_event_capture(enum __daisy_event_set event_set, const __daisy_metadata* metadata) {
+        if (event_set == __DAISY_EVENT_SET_CUDA) {
+            if (metadata->target_type && std::strcmp(metadata->target_type, "CUDA") == 0) {
+                if (ensure_cuda_events()) {
+                    return EventCaptureType::CUDA_EVT;
+                }
+            } else if (metadata->target_type && std::strcmp(metadata->target_type, "ROCM") == 0) {
+                if (ensure_rocm_events()) {
+                    return EventCaptureType::ROCM_EVT;
+                }
+            }
+        }
+        return EventCaptureType::NONE;
+    }
+
     size_t register_region(const __daisy_metadata* metadata, enum __daisy_event_set event_set) {
         std::lock_guard<std::mutex> lock(mutex);
 
@@ -810,6 +888,7 @@ public:
 
         DaisyRegion region;
         std::memcpy(&region.metadata, metadata, sizeof(__daisy_metadata));
+        region.event_capture_type = decide_event_capture(event_set, metadata);
         region.event_set = event_set;
 
         if (this->has_events(region.event_set)) {
@@ -884,11 +963,15 @@ public:
 
         // CUDA regions: record a start event on the stream (async, no host sync)
         // so back-to-back launches stay hot; the paired exit records the stop.
-        if (region.event_set == __DAISY_EVENT_SET_CUDA && ensure_cuda_events()) {
-            region.last_cuda_start = acquire_cuda_event();
-            if (region.last_cuda_start) {
-                cuEventRecord_(region.last_cuda_start, nullptr);
-                DEBUG_PRINTLN("[daisy-rtl] CUDA region " << region.metadata.region_uuid << " start event recorded.");
+        if (region.event_capture_type != EventCaptureType::NONE) {
+            auto& api = get_event_api(region.event_capture_type);
+            region.last_start_event = api.acquire_new_event();
+            if (region.last_start_event) {
+                auto res = api.eventRecord_(region.last_start_event, nullptr);
+                if (res != 0) {
+                    std::cerr << "[daisy-rtl] GPU eventRecord start failed with " << res << "\n";
+                }
+                DEBUG_PRINTLN("[daisy-rtl] GPU region " << region.metadata.region_uuid << " start event recorded.");
             }
         }
     }
@@ -912,20 +995,24 @@ public:
         // CUDA-event timing: record the stop event on the stream and defer the
         // elapsed-time read to stats time. The host clock would only see the async
         // launch, so skip it (and the PAPI-counter path, unused for pure timing).
-        if (region.event_set == __DAISY_EVENT_SET_CUDA && cuda_events_available_ && region.last_cuda_start) {
-            void* stop = acquire_cuda_event();
+        if (region.event_capture_type != EventCaptureType::NONE && region.last_start_event) {
+            auto& api = get_event_api(region.event_capture_type);
+            void* stop = api.acquire_new_event();
             if (stop) {
-                cuEventRecord_(stop, nullptr);
-                DEBUG_PRINTLN("[daisy-rtl] CUDA region " << region.metadata.region_uuid << " stop event recorded.");
-                region.cuda_pending.emplace_back(region.last_cuda_start, stop);
+                auto res = api.eventRecord_(stop, nullptr);
+                if (res != 0) {
+                    std::cerr << "[daisy-rtl] GPU eventRecord stop failed with " << res << "\n";
+                }
+                DEBUG_PRINTLN("[daisy-rtl] GPU region " << region.metadata.region_uuid << " stop event recorded.");
+                region.pending_events.emplace_back(region.last_start_event, stop);
             } else {
                 DEBUG_PRINTLN(
-                    "[daisy-rtl] CUDA region " << region.metadata.region_uuid
-                                               << " stop event failed to acquire; dropping start event."
+                    "[daisy-rtl] GPU region " << region.metadata.region_uuid
+                                              << " stop event failed to acquire; dropping start event."
                 );
-                cuda_event_pool_.push_back(region.last_cuda_start);
+                api.event_pool.push_back(region.last_start_event);
             }
-            region.last_cuda_start = nullptr;
+            region.last_start_event = nullptr;
             return;
         }
 
@@ -1149,6 +1236,12 @@ public:
         }
     }
 
+    void post_process_regions() {
+        for (auto& [region_id, region] : regions) {
+            post_process_region(region);
+        }
+    }
+
 public:
     // Read the running aggregate runtime stats for a region (aggregate mode).
     // Returns false if the region is unknown or has no samples yet. Units:
@@ -1160,7 +1253,7 @@ public:
             return false;
         }
         DaisyRegion& region = it->second;
-        resolve_cuda_pending(region);
+        resolve_pending_events(region);
         if (region.runtime_n <= 0) {
             return false;
         }
@@ -1180,7 +1273,7 @@ public:
         bool any = false;
         for (auto& kv : regions) {
             DaisyRegion& region = kv.second;
-            resolve_cuda_pending(region);
+            resolve_pending_events(region);
             if (region.runtime_n <= 0) {
                 continue;
             }
@@ -1198,6 +1291,17 @@ public:
         return true;
     }
 
+    GpuEventApi& get_event_api(EventCaptureType event_capture) {
+        switch (event_capture) {
+            case EventCaptureType::CUDA_EVT:
+                return cuda_events_;
+            case EventCaptureType::ROCM_EVT:
+                return rocm_events_;
+            default:
+                throw std::runtime_error("There is no known EventCaptureType!");
+        }
+    }
+
     // Clear running aggregate runtime stats for all regions (keeps registration).
     void reset_all_stats() {
         std::lock_guard<std::mutex> lock(mutex);
@@ -1213,12 +1317,15 @@ public:
             // Discard any pending CUDA events (e.g. the warmup launch) so their
             // timing is dropped consistently with the runtime stats above; the
             // events are recycled into the pool.
-            for (auto& [start, stop] : region.cuda_pending) {
-                cuda_event_pool_.push_back(start);
-                cuda_event_pool_.push_back(stop);
+            if (!region.pending_events.empty()) {
+                auto& api = get_event_api(region.event_capture_type);
+                for (auto& [start, stop] : region.pending_events) {
+                    api.event_pool.push_back(start);
+                    api.event_pool.push_back(stop);
+                }
             }
-            region.cuda_pending.clear();
-            region.last_cuda_start = nullptr;
+            region.pending_events.clear();
+            region.last_start_event = nullptr;
 
             // Hardware-counter aggregates, cleared so all metrics drop the
             // warmup sample consistently with the runtime stats above.
@@ -1290,6 +1397,8 @@ void __daisy_instrumentation_start(void) { get_daisy_state().set_enabled(true); 
 void __daisy_instrumentation_stop(void) { get_daisy_state().set_enabled(false); }
 
 bool __daisy_instrumentation_is_enabled(void) { return get_daisy_state().is_enabled(); }
+
+void __daisy_instrumentation_finalize_all(void) { get_daisy_state().post_process_regions(); }
 
 #ifdef __cplusplus
 } // extern "C"

--- a/sdfg/include/sdfg/codegen/instrumentation/instrumentation_plan.h
+++ b/sdfg/include/sdfg/codegen/instrumentation/instrumentation_plan.h
@@ -49,6 +49,8 @@ public:
         const InstrumentationInfo& info
     ) const;
 
+    void leaving_instrumentation_function(PrettyPrinter& stream, LanguageExtension& language_extension) const;
+
     void insert(const Element* node) { nodes_.insert(node); }
 
     static std::unique_ptr<InstrumentationPlan> none(StructuredSDFG& sdfg);

--- a/sdfg/src/codegen/code_generators/c_code_generator.cpp
+++ b/sdfg/src/codegen/code_generators/c_code_generator.cpp
@@ -218,6 +218,7 @@ void CCodeGenerator::dispatch_schedule() {
                 }
             }
         }
+        instrumentation_plan_.leaving_instrumentation_function(this->main_stream_, language_extension_);
     }
     this->main_stream_.changeIndent(-4);
 };

--- a/sdfg/src/codegen/code_generators/cpp_code_generator.cpp
+++ b/sdfg/src/codegen/code_generators/cpp_code_generator.cpp
@@ -236,6 +236,7 @@ void CPPCodeGenerator::dispatch_schedule() {
                 }
             }
         }
+        instrumentation_plan_.leaving_instrumentation_function(this->main_stream_, language_extension_);
     }
     this->main_stream_.changeIndent(-4);
 };

--- a/sdfg/src/codegen/dispatchers/while_dispatcher.cpp
+++ b/sdfg/src/codegen/dispatchers/while_dispatcher.cpp
@@ -117,6 +117,8 @@ void ReturnDispatcher::dispatch_node(
         }
     }
 
+    instrumentation_plan_.leaving_instrumentation_function(main_stream, language_extension_);
+
     if (node_.is_data()) {
         std::string return_str = node_.data();
         if (sdfg_.is_external(node_.data())) {

--- a/sdfg/src/codegen/instrumentation/instrumentation_plan.cpp
+++ b/sdfg/src/codegen/instrumentation/instrumentation_plan.cpp
@@ -152,6 +152,13 @@ void InstrumentationPlan::end_instrumentation(
     stream << "__daisy_instrumentation_finalize(" << region_id_var << ");" << std::endl;
 }
 
+void InstrumentationPlan::leaving_instrumentation_function(PrettyPrinter& stream, LanguageExtension& language_extension)
+    const {
+    if (!this->is_empty()) {
+        stream << "__daisy_instrumentation_finalize_all();" << std::endl;
+    }
+}
+
 std::unique_ptr<InstrumentationPlan> InstrumentationPlan::none(StructuredSDFG& sdfg) {
     return std::make_unique<InstrumentationPlan>(sdfg, std::unordered_set<const Element*>{});
 }


### PR DESCRIPTION
Daisy-rtl will switch to using CUDA events on cuda kernels, because measuring runtime on host will not work well.
Same for ROCm
Disabled in non-aggregate mode, due to us needing also a starttime and not getting a unified start time ouf of the event APIs.

__DAISY_INSTRUMENTATION_ASYNC_CAPTURE=0 overrides default and disables this also for aggregate mode.

Instroduced __daisy_instrumentation_finalize_all at the end of an SDFG, to give rtl lib time to wait on and capture any outstanding async events not captured already (will block here until all captured kernels complete...)