### PR TITLE
Rocm profiling

### DIFF
--- a/mlir/benchmarks/harness.py
+++ b/mlir/benchmarks/harness.py
@@ -1,13 +1,13 @@
 import argparse
 import os
 import sys
+import docc.torch
 import torch
 import torch._dynamo
 import time
 import numpy as np
 import pytest
 
-import docc.torch
 from docc.benchmarks.perf import PerfControl
 from docc.benchmarks import reset_instrumentation
 

--- a/mlir/benchmarks/torch/model_zoo/bn_conv_bn_relu_maxpool.py
+++ b/mlir/benchmarks/torch/model_zoo/bn_conv_bn_relu_maxpool.py
@@ -1,8 +1,9 @@
+import docc.torch
+
 import torch
 import torch.nn as nn
 import pytest
 
-import docc.torch
 
 class SubModel(nn.Module):
     def __init__(self):
@@ -21,12 +22,14 @@ class SubModel(nn.Module):
         x = self.maxpool(x)
         return x
 
+
 def setup():
     """Return (eval-mode model, example_input) for the full pipeline."""
     model = SubModel()
     model.eval()
     x = torch.randn(1, 3, 224, 224)
     return model, x
+
 
 if __name__ == "__main__":
     from benchmarks.harness import run_benchmark

--- a/mlir/benchmarks/torch/model_zoo/conftest.py
+++ b/mlir/benchmarks/torch/model_zoo/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+
+import docc.torch
 import torch
 
 

--- a/mlir/benchmarks/torch/model_zoo/fasterrcnn_resnet50.py
+++ b/mlir/benchmarks/torch/model_zoo/fasterrcnn_resnet50.py
@@ -1,3 +1,5 @@
+import docc.torch
+
 import torch
 import torchvision.models as models
 import time
@@ -5,16 +7,15 @@ import os
 import sys
 
 # Use Agg backend for headless CI environments
-if os.environ.get('CI') or os.environ.get('GITHUB_ACTIONS'):
+if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"):
     import matplotlib
-    matplotlib.use('Agg')
+
+    matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt
 import PIL.Image as Image
 import requests
 import copy
-
-import docc.torch
 
 # Load a pre-trained Faster R-CNN model
 weights = models.detection.FasterRCNN_ResNet50_FPN_Weights.DEFAULT
@@ -53,7 +54,7 @@ image = Image.open(requests.get(url, stream=True).raw)
 
 input_tensor = transforms(image)
 
-if not (os.environ.get('CI') or os.environ.get('GITHUB_ACTIONS')):
+if not (os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS")):
     _ = plt.imshow(image)
     plt.title("Input Image")
     plt.axis("off")
@@ -76,28 +77,36 @@ with torch.no_grad():
     print("\n--- Results Comparison ---")
 
     # Compare outputs - these assertions will fail the test if results don't match
-    number_of_outputs_match = (len(res) == len(ref) and len(res) == 1 and len(res[0]['labels']) == len(ref[0]['labels']))
+    number_of_outputs_match = (
+        len(res) == len(ref)
+        and len(res) == 1
+        and len(res[0]["labels"]) == len(ref[0]["labels"])
+    )
     if number_of_outputs_match:
         print("✓ Number of outputs match between docc and torch")
     else:
-        print(f"✗ Number of outputs differ: {len(res[0]['labels'])} != {len(ref[0]['labels'])}")
-    
-    # Assert here because else the other checks crash
-    assert number_of_outputs_match, "Number of outputs don't match between docc and torch inductor"
+        print(
+            f"✗ Number of outputs differ: {len(res[0]['labels'])} != {len(ref[0]['labels'])}"
+        )
 
-    boxes_match = torch.allclose(res[0]['boxes'], ref[0]['boxes'], rtol=1e-2)
+    # Assert here because else the other checks crash
+    assert (
+        number_of_outputs_match
+    ), "Number of outputs don't match between docc and torch inductor"
+
+    boxes_match = torch.allclose(res[0]["boxes"], ref[0]["boxes"], rtol=1e-2)
     if boxes_match:
         print("✓ Boxes match between docc and torch")
     else:
         print("✗ Boxes differ with a relative difference of:")
-        print((res[0]['boxes'] - ref[0]['boxes']) / ref[0]['boxes'])
+        print((res[0]["boxes"] - ref[0]["boxes"]) / ref[0]["boxes"])
 
-    scores_match = torch.allclose(res[0]['scores'], ref[0]['scores'], rtol=1e-2)
+    scores_match = torch.allclose(res[0]["scores"], ref[0]["scores"], rtol=1e-2)
     if scores_match:
         print("✓ Scores match between docc and torch")
     else:
         print("✗ Scores differ with a relative difference of:")
-        print((res[0]['scores'] - ref[0]['scores']) / ref[0]['scores'])
+        print((res[0]["scores"] - ref[0]["scores"]) / ref[0]["scores"])
 
     print(f"\nDetected {len(res[0]['boxes'])} objects with docc")
     print(f"Detected {len(ref[0]['boxes'])} objects with torch inductor")
@@ -109,11 +118,19 @@ with torch.no_grad():
 
 
 # Draw the predicted bounding boxes (only in interactive mode, not CI)
-if not (os.environ.get('CI') or os.environ.get('GITHUB_ACTIONS')):
+if not (os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS")):
     # COCO labels for object detection
     labels = weights.meta["categories"]
 
-    def draw_boxes(image, boxes, classes, labels, scores, threshold=0.4, title="Predicted Bounding Boxes"):
+    def draw_boxes(
+        image,
+        boxes,
+        classes,
+        labels,
+        scores,
+        threshold=0.4,
+        title="Predicted Bounding Boxes",
+    ):
         plt.figure(figsize=(8, 8))
         plt.imshow(image)
         ax = plt.gca()
@@ -133,7 +150,23 @@ if not (os.environ.get('CI') or os.environ.get('GITHUB_ACTIONS')):
         plt.title(title)
         plt.show()
 
-    draw_boxes(image, ref[0]["boxes"].cpu().numpy(), ref[0]["labels"].cpu().numpy(), labels, ref[0]["scores"].cpu().numpy(), threshold=0.5, title="Torch Detections")
-    draw_boxes(image, res[0]["boxes"].cpu().numpy(), res[0]["labels"].cpu().numpy(), labels, res[0]["scores"].cpu().numpy(), threshold=0.5, title="DOCC Detections")
+    draw_boxes(
+        image,
+        ref[0]["boxes"].cpu().numpy(),
+        ref[0]["labels"].cpu().numpy(),
+        labels,
+        ref[0]["scores"].cpu().numpy(),
+        threshold=0.5,
+        title="Torch Detections",
+    )
+    draw_boxes(
+        image,
+        res[0]["boxes"].cpu().numpy(),
+        res[0]["labels"].cpu().numpy(),
+        labels,
+        res[0]["scores"].cpu().numpy(),
+        threshold=0.5,
+        title="DOCC Detections",
+    )
 else:
     print("\nSkipping visualization in CI environment")

--- a/mlir/benchmarks/torch/model_zoo/resnet18.py
+++ b/mlir/benchmarks/torch/model_zoo/resnet18.py
@@ -1,9 +1,9 @@
+import docc.torch
+
 import torch
 import torch.nn as nn
 import torchvision.models as models
 from functools import partial
-
-import docc.torch
 
 
 class Resnet18BasicBlock(nn.Module):

--- a/mlir/benchmarks/torch/model_zoo/segformer.py
+++ b/mlir/benchmarks/torch/model_zoo/segformer.py
@@ -1,4 +1,5 @@
 import pytest
+import docc.torch
 
 import torch
 import torch.nn as nn

--- a/mlir/docc/torch/__init__.py
+++ b/mlir/docc/torch/__init__.py
@@ -1,3 +1,10 @@
+from docc.benchmarks.rtl import try_ensure_instrumentation_ready
+
+# Ready the counter backends (e.g. ROCm) early: they must initialize before the
+# workload sets up its own runtime. Best-effort so importing docc never fails when
+# instrumentation is not configured.
+try_ensure_instrumentation_ready()
+
 from docc.torch.torch_program import (
     TorchProgram,
     compile_torch,

--- a/mlir/integration/torch/check.py
+++ b/mlir/integration/torch/check.py
@@ -1,8 +1,7 @@
+import docc.torch
 import torch
 import copy
 from math import isnan
-
-import docc.torch
 
 
 def compare(

--- a/python/docc/benchmarks/rtl.py
+++ b/python/docc/benchmarks/rtl.py
@@ -52,6 +52,9 @@ __all__ = [
     "start_instrumentation",
     "stop_instrumentation",
     "instrumentation_enabled",
+    "ensure_instrumentation_ready",
+    "try_ensure_instrumentation_ready",
+    "InstrumentationNotReady",
     "total_stats",
     "RtlTotalStats",
 ]
@@ -222,6 +225,63 @@ def instrumentation_enabled() -> Optional[bool]:
     fn.restype = ctypes.c_bool
     fn.argtypes = []
     return bool(fn())
+
+
+class InstrumentationNotReady(RuntimeError):
+    """Raised when the daisy RTL cannot be loaded or initialized eagerly."""
+
+
+def ensure_instrumentation_ready() -> None:
+    """Eagerly load and initialize the daisy RTL instrumentation library.
+
+    Some counter backends (notably ROCm) must be initialized before the
+    application under measurement sets up its own runtime, otherwise the counters
+    are unavailable. Loading the shared RTL and calling a native entry point forces
+    construction of the process-global instrumentation state, which readies the
+    underlying PAPI/ROCm libraries now instead of lazily on the first measured
+    region.
+
+    Raises :class:`InstrumentationNotReady` if the shared RTL cannot be located,
+    loaded, or its entry point invoked. Note the native initializer aborts the
+    process when ``__DAISY_PAPI_VERSION`` is unset or PAPI is unavailable; use
+    :func:`try_ensure_instrumentation_ready` when that must be avoided.
+    """
+    lib = _rtl_lib()
+    if lib is None:
+        raise InstrumentationNotReady(
+            "Could not locate or load libdaisy_rtl; set DAISY_RTL_LIB or ensure "
+            "the shared RTL is on the library search path."
+        )
+    try:
+        # Subscript access bypasses ctypes' dunder-name guard.
+        fn = lib[_RTL_IS_ENABLED_SYMBOL]
+    except (AttributeError, KeyError, ValueError) as exc:
+        raise InstrumentationNotReady(
+            f"RTL is missing the {_RTL_IS_ENABLED_SYMBOL} entry point."
+        ) from exc
+    fn.restype = ctypes.c_bool
+    fn.argtypes = []
+    # The call triggers construction of the process-global state, readying PAPI/ROCm.
+    fn()
+
+
+def try_ensure_instrumentation_ready() -> bool:
+    """Best-effort :func:`ensure_instrumentation_ready` that never raises.
+
+    Returns ``True`` if the RTL was readied, ``False`` otherwise. Initialization is
+    only attempted when ``__DAISY_PAPI_VERSION`` is set (the native initializer
+    aborts the process if it is missing) and the RTL library can be located, so on a
+    machine without instrumentation configured this is a cheap no-op.
+    """
+    if not os.environ.get("__DAISY_PAPI_VERSION"):
+        return False
+    if _find_rtl_lib() is None:
+        return False
+    try:
+        ensure_instrumentation_ready()
+        return True
+    except Exception:
+        return False
 
 
 @dataclass(frozen=True)

--- a/python/docc/python/__init__.py
+++ b/python/docc/python/__init__.py
@@ -8,6 +8,12 @@ from docc.compiler.target_registry import (
     unregister_target,
     reset_target_registry,
 )
+from docc.benchmarks.rtl import try_ensure_instrumentation_ready
 
 # Backward compatibility alias - ExpressionVisitor is now merged into ASTParser
 ExpressionVisitor = ASTParser
+
+# Ready the counter backends (e.g. ROCm) early: they must initialize before the
+# workload sets up its own runtime. Best-effort so importing docc never fails when
+# instrumentation is not configured.
+try_ensure_instrumentation_ready()

--- a/pytorch/benchmarks/harness.py
+++ b/pytorch/benchmarks/harness.py
@@ -1,13 +1,13 @@
 import argparse
 import os
 import sys
+import docc.pytorch
 import torch
 import torch._dynamo
 import time
 import numpy as np
 import pytest
 
-import docc.pytorch
 from docc.benchmarks.perf import PerfControl
 from docc.benchmarks.rtl import reset_instrumentation
 

--- a/pytorch/benchmarks/models/resnet18.py
+++ b/pytorch/benchmarks/models/resnet18.py
@@ -1,9 +1,9 @@
+import docc.pytorch
+
 import torch
 import torch.nn as nn
 import torchvision.models as models
 from functools import partial
-
-import docc.pytorch
 
 
 class Resnet18BasicBlock(nn.Module):

--- a/pytorch/benchmarks/models/segformer.py
+++ b/pytorch/benchmarks/models/segformer.py
@@ -1,5 +1,6 @@
 import pytest
 
+import docc.pytorch
 import torch
 import torch.nn as nn
 import transformers

--- a/pytorch/docc/pytorch/__init__.py
+++ b/pytorch/docc/pytorch/__init__.py
@@ -1,2 +1,9 @@
+from docc.benchmarks.rtl import try_ensure_instrumentation_ready
+
+# Ready the counter backends (e.g. ROCm) early: they must initialize before the
+# workload sets up its own runtime. Best-effort so importing docc never fails when
+# instrumentation is not configured.
+try_ensure_instrumentation_ready()
+
 from docc.pytorch.pytorch_program import PyTorchProgram
 from docc.pytorch.graph_parser import GraphParser

--- a/pytorch/tests/__init__.py
+++ b/pytorch/tests/__init__.py
@@ -1,10 +1,9 @@
 import numpy as np
+import docc.pytorch
 import torch
 import copy
 from math import isnan
 from typing import Any
-
-import docc.pytorch
 
 
 def compare_shapes(res_shape: torch.Size, ref_shape: torch.Size) -> None:

--- a/rtl/src/instrumentation.cpp
+++ b/rtl/src/instrumentation.cpp
@@ -52,6 +52,7 @@ static int (*_PAPI_library_init)(int) = nullptr;
 static int (*_PAPI_create_eventset)(int*) = nullptr;
 static int (*_PAPI_cleanup_eventset)(int) = nullptr;
 static int (*_PAPI_destroy_eventset)(int*) = nullptr;
+static int (*_PAPI_query_named_event)(const char*) = nullptr;
 static int (*_PAPI_add_named_event)(int, const char*) = nullptr;
 static int (*_PAPI_start)(int) = nullptr;
 static int (*_PAPI_stop)(int, long long*) = nullptr;
@@ -72,6 +73,7 @@ static void load_papi_symbols() {
     _PAPI_create_eventset = reinterpret_cast<int (*)(int*)>(dlsym(handle, "PAPI_create_eventset"));
     _PAPI_cleanup_eventset = reinterpret_cast<int (*)(int)>(dlsym(handle, "PAPI_cleanup_eventset"));
     _PAPI_destroy_eventset = reinterpret_cast<int (*)(int*)>(dlsym(handle, "PAPI_destroy_eventset"));
+    _PAPI_query_named_event = reinterpret_cast<int (*)(const char*)>(dlsym(handle, "PAPI_query_named_event"));
     _PAPI_add_named_event = reinterpret_cast<int (*)(int, const char*)>(dlsym(handle, "PAPI_add_named_event"));
     _PAPI_start = reinterpret_cast<int (*)(int)>(dlsym(handle, "PAPI_start"));
     _PAPI_stop = reinterpret_cast<int (*)(int, long long*)>(dlsym(handle, "PAPI_stop"));
@@ -512,12 +514,26 @@ public:
         const char* env_events_cpu = std::getenv("__DAISY_INSTRUMENTATION_EVENTS");
         if (env_events_cpu) {
             split_string(env_events_cpu, this->event_names_cpu);
+            for (const auto& event_name : this->event_names_cpu) {
+                int event_code;
+                if (_PAPI_query_named_event(event_name.c_str()) != 0) {
+                    std::fprintf(stderr, "[daisy-rtl] PAPI event '%s' not found.\n", event_name.c_str());
+                    exit(EXIT_FAILURE);
+                }
+            }
         }
 
         // Events - CUDA
         const char* env_events_cuda = std::getenv("__DAISY_INSTRUMENTATION_EVENTS_CUDA");
         if (env_events_cuda) {
             split_string(env_events_cuda, this->event_names_cuda);
+            for (const auto& event_name : this->event_names_cuda) {
+                int event_code;
+                if (_PAPI_query_named_event(event_name.c_str()) != 0) {
+                    std::fprintf(stderr, "[daisy-rtl] PAPI event '%s' not found.\n", event_name.c_str());
+                    exit(EXIT_FAILURE);
+                }
+            }
         }
     }
 

--- a/rtl/src/instrumentation.cpp
+++ b/rtl/src/instrumentation.cpp
@@ -467,6 +467,16 @@ private:
         std::fprintf(f, "%s", entry.str().c_str());
     }
 
+    void verify_events_exist(const std::vector<std::string>& list) {
+        for (const auto& event_name : list) {
+            int event_code;
+            if (_PAPI_query_named_event(event_name.c_str()) != 0) {
+                std::fprintf(stderr, "[daisy-rtl] PAPI event '%s' not found.\n", event_name.c_str());
+                exit(EXIT_FAILURE);
+            }
+        }
+    }
+
 public:
     DaisyInstrumentationState() {
         load_papi_symbols();
@@ -514,26 +524,14 @@ public:
         const char* env_events_cpu = std::getenv("__DAISY_INSTRUMENTATION_EVENTS");
         if (env_events_cpu) {
             split_string(env_events_cpu, this->event_names_cpu);
-            for (const auto& event_name : this->event_names_cpu) {
-                int event_code;
-                if (_PAPI_query_named_event(event_name.c_str()) != 0) {
-                    std::fprintf(stderr, "[daisy-rtl] PAPI event '%s' not found.\n", event_name.c_str());
-                    exit(EXIT_FAILURE);
-                }
-            }
+            verify_events_exist(this->event_names_cpu);
         }
 
         // Events - CUDA
         const char* env_events_cuda = std::getenv("__DAISY_INSTRUMENTATION_EVENTS_CUDA");
         if (env_events_cuda) {
             split_string(env_events_cuda, this->event_names_cuda);
-            for (const auto& event_name : this->event_names_cuda) {
-                int event_code;
-                if (_PAPI_query_named_event(event_name.c_str()) != 0) {
-                    std::fprintf(stderr, "[daisy-rtl] PAPI event '%s' not found.\n", event_name.c_str());
-                    exit(EXIT_FAILURE);
-                }
-            }
+            verify_events_exist(this->event_names_cuda);
         }
     }
 


### PR DESCRIPTION
Initialize daisy_rtl explicitly from our python code, so it can prepare rocm instrumentation before anyone else initalizes rocm without instrumentation support.

daisy_rtl will now also verify the existence of all counters it is supposed to track during initialization.

This should make most of our benchmark cases work with rocm profiling