### PR TITLE
emit multi-dimensional buffers in LocalStorage

### DIFF
--- a/opt/include/sdfg/transformations/local_storage.h
+++ b/opt/include/sdfg/transformations/local_storage.h
@@ -113,6 +113,19 @@ public:
         /// Decompose a flat tile index (0..product(tile_sizes)) into per-tile-dim
         /// indices (row-major).
         std::vector<symbolic::Expression> delinearize_tile(const symbolic::Expression& flat) const;
+
+        /// GPU-shared only: pad the per-slot inner block stride to be coprime with
+        /// 32 so a warp's per-slot accesses land on distinct banks (no bank
+        /// conflicts). When set, the buffer is laid out `[slot dims][inner_stride]`
+        /// with a flat per-slot block, and axes()/multi_subset() switch to that
+        /// form. Set by apply() for an NV_Shared buffer that owns a slot prefix.
+        bool bank_padded = false;
+        /// Per-slot inner block stride: tile_total_size() bumped to the next value
+        /// coprime with 32 (i.e. odd) when bank_padded and the size is a constant;
+        /// tile_total_size() otherwise.
+        symbolic::Expression inner_stride() const;
+        /// Flat row-major offset of @p tile_indices within one per-slot block.
+        symbolic::Expression tile_linearize(const std::vector<symbolic::Expression>& tile_indices) const;
     };
 
     /// How a container is accessed within a loop, read straight off the

--- a/opt/include/sdfg/transformations/local_storage.h
+++ b/opt/include/sdfg/transformations/local_storage.h
@@ -99,6 +99,17 @@ public:
         symbolic::Expression linearize(
             const std::vector<symbolic::Expression>& slot_indices, const std::vector<symbolic::Expression>& tile_indices
         ) const;
+        /// Ordered buffer axes, outermost-first: [slot_sizes ++ tile_sizes]. Each
+        /// axis becomes one dimension of the nested-array buffer type, so the
+        /// per-axis stride is recoverable from that array level's num_elements.
+        /// Empty for a degenerate (all extent-1, no-slot) tile.
+        std::vector<symbolic::Expression> axes() const;
+        /// Multi-dimensional buffer subset [slot_indices ++ tile_indices], one
+        /// index per axis, matching the nested-array buffer type. A degenerate
+        /// (no-axis) buffer is addressed with the single index {0}.
+        data_flow::Subset multi_subset(
+            const std::vector<symbolic::Expression>& slot_indices, const std::vector<symbolic::Expression>& tile_indices
+        ) const;
         /// Decompose a flat tile index (0..product(tile_sizes)) into per-tile-dim
         /// indices (row-major).
         std::vector<symbolic::Expression> delinearize_tile(const symbolic::Expression& flat) const;

--- a/opt/src/transformations/local_storage.cpp
+++ b/opt/src/transformations/local_storage.cpp
@@ -380,6 +380,13 @@ symbolic::Expression LocalStorage::TileBuffer::linearize(
 }
 
 std::vector<symbolic::Expression> LocalStorage::TileBuffer::axes() const {
+    if (bank_padded) {
+        // [slot dims][padded per-slot block]: the inner block is one flat, padded
+        // dimension so its stride (inner_stride) is coprime with 32.
+        std::vector<symbolic::Expression> out = slot_sizes;
+        out.push_back(inner_stride());
+        return out;
+    }
     std::vector<symbolic::Expression> out = slot_sizes;
     out.insert(out.end(), tile_sizes.begin(), tile_sizes.end());
     return out;
@@ -389,13 +396,45 @@ data_flow::Subset LocalStorage::TileBuffer::multi_subset(
     const std::vector<symbolic::Expression>& slot_indices, const std::vector<symbolic::Expression>& tile_indices
 ) const {
     data_flow::Subset subset = slot_indices;
-    subset.insert(subset.end(), tile_indices.begin(), tile_indices.end());
+    if (bank_padded) {
+        // Flatten the tile indices into the single padded inner dimension.
+        subset.push_back(tile_linearize(tile_indices));
+    } else {
+        subset.insert(subset.end(), tile_indices.begin(), tile_indices.end());
+    }
     // A degenerate (all extent-1, no-slot) tile has no axes; the buffer is a
     // single [1] element addressed at index 0.
     if (subset.empty()) {
         subset.push_back(symbolic::integer(0));
     }
     return subset;
+}
+
+symbolic::Expression LocalStorage::TileBuffer::tile_linearize(const std::vector<symbolic::Expression>& tile_indices
+) const {
+    symbolic::Expression linear = symbolic::integer(0);
+    symbolic::Expression stride = symbolic::integer(1);
+    for (int i = static_cast<int>(tile_indices.size()) - 1; i >= 0; i--) {
+        linear = symbolic::add(linear, symbolic::mul(tile_indices[i], stride));
+        if (i < static_cast<int>(tile_sizes.size())) {
+            stride = symbolic::mul(stride, tile_sizes[i]);
+        }
+    }
+    return linear;
+}
+
+symbolic::Expression LocalStorage::TileBuffer::inner_stride() const {
+    auto total = tile_total_size();
+    // Pad only a constant block to the next odd size (coprime with 32); a
+    // symbolic block cannot be safely padded, so leave it unpadded.
+    if (!SymEngine::is_a<SymEngine::Integer>(*total)) {
+        return total;
+    }
+    auto n = SymEngine::rcp_static_cast<const SymEngine::Integer>(total)->as_int();
+    if (n % 2 == 0) {
+        return symbolic::integer(n + 1);
+    }
+    return total;
 }
 
 std::vector<symbolic::Expression> LocalStorage::TileBuffer::delinearize_tile(const symbolic::Expression& flat) const {
@@ -963,6 +1002,10 @@ void LocalStorage::apply(builder::StructuredSDFGBuilder& builder, analysis::Anal
     }
 
     TileBuffer buffer{slot_sizes, tile_info_.varying_sizes()};
+    // GPU shared buffers with a per-thread slot prefix pad the inner block stride
+    // to be coprime with 32, so a warp's per-slot accesses hit distinct banks (no
+    // bank conflicts). CPU/private buffers keep the dense multi-dim layout.
+    buffer.bank_padded = storage_type_.is_nv_shared() && !slot_sizes.empty();
     // Multi-dimensional (nested-array) buffer: one array level per [slot ++ tile]
     // axis, so every access is a clean per-axis subset and clang recovers the
     // strides from each level's num_elements (instead of a single collapsed
@@ -1145,8 +1188,14 @@ void LocalStorage::emit_cooperative_copy_in(
     auto& src = builder.add_access(block, container_);
     auto& dst = builder.add_access(block, local_name_);
     auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
-    // Per-thread slot row followed by the delinearized tile indices.
-    data_flow::Subset dst_subset = buffer.multi_subset(slot_indices, decomp);
+    // Per-thread slot row followed by the (flat, when bank-padded) tile offset.
+    data_flow::Subset dst_subset;
+    if (buffer.bank_padded) {
+        dst_subset = slot_indices;
+        dst_subset.push_back(c);
+    } else {
+        dst_subset = buffer.multi_subset(slot_indices, decomp);
+    }
     builder.add_computational_memlet(block, src, tasklet, "_in", coop_original, pointer_type);
     builder.add_computational_memlet(block, tasklet, "_out", dst, dst_subset, buffer_type);
 

--- a/opt/src/transformations/local_storage.cpp
+++ b/opt/src/transformations/local_storage.cpp
@@ -33,6 +33,25 @@ namespace transformations {
 
 namespace {
 
+/// Build the nested-array buffer type `elem[axes[0]][axes[1]]...` (outermost
+/// first). Only the outermost array carries @p storage; the inner arrays and the
+/// scalar element keep default storage so the declaration emits a single storage
+/// qualifier. Each array level's num_elements is the per-axis stride source, so
+/// codegen recovers multi-dimensional strides directly from the type. A
+/// degenerate (no-axis) tile becomes a single-element [1] buffer.
+std::unique_ptr<types::IType> make_nested_array(
+    const std::vector<symbolic::Expression>& axes, const types::IType& scalar, const types::StorageType& storage
+) {
+    if (axes.empty()) {
+        return std::make_unique<types::Array>(storage, 0, "", scalar, symbolic::integer(1));
+    }
+    std::unique_ptr<types::IType> inner = scalar.clone();
+    for (size_t a = axes.size() - 1; a >= 1; a--) {
+        inner = std::make_unique<types::Array>(*inner, axes[a]);
+    }
+    return std::make_unique<types::Array>(storage, 0, "", *inner, axes[0]);
+}
+
 /// Visit every Block reachable under @p node (recursing through sequences,
 /// loops, and if-else branches).
 void for_each_block(
@@ -358,6 +377,25 @@ symbolic::Expression LocalStorage::TileBuffer::linearize(
         stride = symbolic::mul(stride, sizes[i]);
     }
     return linear;
+}
+
+std::vector<symbolic::Expression> LocalStorage::TileBuffer::axes() const {
+    std::vector<symbolic::Expression> out = slot_sizes;
+    out.insert(out.end(), tile_sizes.begin(), tile_sizes.end());
+    return out;
+}
+
+data_flow::Subset LocalStorage::TileBuffer::multi_subset(
+    const std::vector<symbolic::Expression>& slot_indices, const std::vector<symbolic::Expression>& tile_indices
+) const {
+    data_flow::Subset subset = slot_indices;
+    subset.insert(subset.end(), tile_indices.begin(), tile_indices.end());
+    // A degenerate (all extent-1, no-slot) tile has no axes; the buffer is a
+    // single [1] element addressed at index 0.
+    if (subset.empty()) {
+        subset.push_back(symbolic::integer(0));
+    }
+    return subset;
 }
 
 std::vector<symbolic::Expression> LocalStorage::TileBuffer::delinearize_tile(const symbolic::Expression& flat) const {
@@ -925,7 +963,12 @@ void LocalStorage::apply(builder::StructuredSDFGBuilder& builder, analysis::Anal
     }
 
     TileBuffer buffer{slot_sizes, tile_info_.varying_sizes()};
-    types::Array buffer_type(storage_type_, 0, {}, scalar_type, buffer.total_size());
+    // Multi-dimensional (nested-array) buffer: one array level per [slot ++ tile]
+    // axis, so every access is a clean per-axis subset and clang recovers the
+    // strides from each level's num_elements (instead of a single collapsed
+    // linear index with div/mod that defeats load/store vectorization).
+    auto buffer_type_ptr = make_nested_array(buffer.axes(), scalar_type, storage_type_);
+    auto& buffer_type = *buffer_type_ptr;
     builder.add_container(local_name_, buffer_type);
 
     if (storage_type_.is_nv_shared()) {
@@ -1015,7 +1058,7 @@ void LocalStorage::emit_private_copy(
     }
 
     data_flow::Subset original_subset = tile_info_.original_subset(indvars);
-    data_flow::Subset buffer_subset = {buffer.linearize({}, indvars)};
+    data_flow::Subset buffer_subset = buffer.multi_subset({}, indvars);
     // Element-predicate the global access: the over-approximated tile may address
     // out-of-bounds global memory on ragged blocks. Skip those elements (the
     // buffer slots they'd fill are never consumed — the compute's own boundary
@@ -1102,8 +1145,8 @@ void LocalStorage::emit_cooperative_copy_in(
     auto& src = builder.add_access(block, container_);
     auto& dst = builder.add_access(block, local_name_);
     auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
-    // Buffer slot offset (per-thread row) plus the flat tile index c.
-    data_flow::Subset dst_subset = {symbolic::add(buffer.slot_offset(slot_indices), c)};
+    // Per-thread slot row followed by the delinearized tile indices.
+    data_flow::Subset dst_subset = buffer.multi_subset(slot_indices, decomp);
     builder.add_computational_memlet(block, src, tasklet, "_in", coop_original, pointer_type);
     builder.add_computational_memlet(block, tasklet, "_out", dst, dst_subset, buffer_type);
 
@@ -1147,7 +1190,7 @@ void LocalStorage::emit_enclosing_cooperative_copy_in(
     auto& src = builder.add_access(block, container_);
     auto& dst = builder.add_access(block, local_name_);
     auto& tasklet = builder.add_tasklet(block, data_flow::TaskletCode::assign, "_out", {"_in"});
-    data_flow::Subset dst_subset = {c};
+    data_flow::Subset dst_subset = buffer.multi_subset({}, decomp);
     builder.add_computational_memlet(block, src, tasklet, "_in", tile_info_.original_subset(decomp), pointer_type);
     builder.add_computational_memlet(block, tasklet, "_out", dst, dst_subset, buffer_type);
 
@@ -1185,7 +1228,7 @@ void LocalStorage::rewrite_body(
                 if (!acc || acc->subset.size() != tile_info_.dimensions.size()) {
                     return;
                 }
-                memlet.set_subset({buffer.linearize(slot_indices, tile_info_.local_index(acc->subset))});
+                memlet.set_subset(buffer.multi_subset(slot_indices, tile_info_.local_index(acc->subset)));
                 memlet.set_base_type(buffer_type);
                 rewrote = true;
             };

--- a/opt/tests/transformations/test_local_storage.cpp
+++ b/opt/tests/transformations/test_local_storage.cpp
@@ -3070,9 +3070,11 @@ TEST(LocalStorageTest, Apply_Cooperative_Mixed) {
 
     auto buf = xform.local_container();
     ASSERT_TRUE(builder.subject().exists(buf));
-    // Buffer = [slot(BM=8)] x [tile(16)] = 128 shared elements.
+    // Buffer = [slot(BM=8)] x [tile(16)] = float[8][16] shared elements.
     EXPECT_TRUE(builder.subject().type(buf).storage_type().is_nv_shared());
-    EXPECT_TRUE(builder.subject().type(buf) == types::Array(elem, symbolic::integer(128)));
+    EXPECT_TRUE(
+        builder.subject().type(buf) == types::Array(types::Array(elem, symbolic::integer(16)), symbolic::integer(8))
+    );
 
     // The cooperative map body is [leading barrier, copy_map, trailing barrier, k-loop].
     ASSERT_EQ(map_j.root().size(), 4u);
@@ -3157,9 +3159,11 @@ TEST(LocalStorageTest, Apply_Cooperative_Mixed_CoopOuter) {
 
     auto buf = xform.local_container();
     ASSERT_TRUE(builder.subject().exists(buf));
-    // Buffer = [slot(i width = 8)] x [tile(16)] = 128 shared elements.
+    // Buffer = [slot(i width = 8)] x [tile(16)] = float[8][16] shared elements.
     EXPECT_TRUE(builder.subject().type(buf).storage_type().is_nv_shared());
-    EXPECT_TRUE(builder.subject().type(buf) == types::Array(elem, symbolic::integer(128)));
+    EXPECT_TRUE(
+        builder.subject().type(buf) == types::Array(types::Array(elem, symbolic::integer(16)), symbolic::integer(8))
+    );
 
     // The copy sits in the immediately-enclosing (per-thread) map's body:
     // [leading barrier, copy_map, trailing barrier, k-loop].

--- a/opt/tests/transformations/test_local_storage.cpp
+++ b/opt/tests/transformations/test_local_storage.cpp
@@ -3070,10 +3070,11 @@ TEST(LocalStorageTest, Apply_Cooperative_Mixed) {
 
     auto buf = xform.local_container();
     ASSERT_TRUE(builder.subject().exists(buf));
-    // Buffer = [slot(BM=8)] x [tile(16)] = float[8][16] shared elements.
+    // Buffer = [slot(BM=8)] x [padded per-slot block]: tile 16 -> 17 (coprime with
+    // 32) to avoid shared-memory bank conflicts.
     EXPECT_TRUE(builder.subject().type(buf).storage_type().is_nv_shared());
     EXPECT_TRUE(
-        builder.subject().type(buf) == types::Array(types::Array(elem, symbolic::integer(16)), symbolic::integer(8))
+        builder.subject().type(buf) == types::Array(types::Array(elem, symbolic::integer(17)), symbolic::integer(8))
     );
 
     // The cooperative map body is [leading barrier, copy_map, trailing barrier, k-loop].
@@ -3159,10 +3160,11 @@ TEST(LocalStorageTest, Apply_Cooperative_Mixed_CoopOuter) {
 
     auto buf = xform.local_container();
     ASSERT_TRUE(builder.subject().exists(buf));
-    // Buffer = [slot(i width = 8)] x [tile(16)] = float[8][16] shared elements.
+    // Buffer = [slot(i width = 8)] x [padded per-slot block]: tile 16 -> 17 (coprime
+    // with 32) to avoid shared-memory bank conflicts.
     EXPECT_TRUE(builder.subject().type(buf).storage_type().is_nv_shared());
     EXPECT_TRUE(
-        builder.subject().type(buf) == types::Array(types::Array(elem, symbolic::integer(16)), symbolic::integer(8))
+        builder.subject().type(buf) == types::Array(types::Array(elem, symbolic::integer(17)), symbolic::integer(8))
     );
 
     // The copy sits in the immediately-enclosing (per-thread) map's body:


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill out this template to help reviewers
understand your changes. Remove sections that are not relevant.
-->

## Description
Changes local storage to emit multi-dimensional buffers. For GPUs, it pads the buffers to odd sizes to avoid bank conflicts. In this case, it emits two dimensions with partially linearized expressions.

## Related Issues
<!-- Link issues this PR closes or relates to, e.g. "Closes #123" -->
- Closes #

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor / internal change (no functional change)
- [ ] Documentation update

## Quality Checklist
*Please ensure the following are completed before requesting review:*

* [ ] Runtime-compatible (no externally visible existing method has its parameters changed, was deleted or has its exception behavior changed)
* [ ] Compile-time compatible (new arguments & properties added have default values, but users need to recompile against the new version to work)

IR:
* [ ] Introduces new types into the SDFG IR
* [ ]  Changed / added properties on SDFG IR Elements (LibraryNodes, ControlFlowNodes DataFlowNodes etc.)
  *  [ ] New / modified types have serialization / deserialization support
  *  [ ] Deserialization is backward compatible (new serialization can deserialize old format and represent it in the new format if applicable)
  *  [ ] Serialized format is backward compatible (previous deserializer can read new serialized format without incorrectness (just lacking additional guarantees that are optional or did not exist before)
  *  [ ] Serializer has an option to emit the previous format

### Unit Tests
- [ ] New unit tests have been added for the changes.
- [ ] Existing unit tests pass locally.
- [ ] Edge cases and error paths are covered.

### Integration Tests
- [ ] New integration tests have been added (or existing ones updated).
- [ ] Integration tests pass locally.
- [ ] Interactions with other components/services are verified.

### Documentation
- [ ] Public APIs, options, and behavior changes are documented.
- [ ] README / docs site / inline comments updated where applicable.
- [ ] Changelog / release notes updated (if applicable).

### Test Coverage
- [ ] Test coverage has not decreased as a result of this change.
- [ ] Coverage report reviewed and acceptable.
- [ ] Critical / new code paths are covered.

## How Has This Been Tested?
Describe the tests you ran to verify your changes and provide instructions to reproduce.
Include relevant details for your test configuration (OS, Python/LLVM/Docc version, hardware/target).

## Additional Context
Add any other context about the PR here (design decisions, trade-offs, follow-ups).
