### PR TITLE
Reduced indvar sizes

### DIFF
--- a/examples/transfer-server/res/matmul.sdfg.json
+++ b/examples/transfer-server/res/matmul.sdfg.json
@@ -107,7 +107,7 @@
             "K": {
                 "alignment": 0,
                 "initializer": "",
-                "primitive_type": 10,
+                "primitive_type": 5,
                 "storage_type": {
                     "allocation": 0,
                     "deallocation": 0,
@@ -118,7 +118,7 @@
             "M": {
                 "alignment": 0,
                 "initializer": "",
-                "primitive_type": 10,
+                "primitive_type": 5,
                 "storage_type": {
                     "allocation": 0,
                     "deallocation": 0,
@@ -129,7 +129,7 @@
             "N": {
                 "alignment": 0,
                 "initializer": "",
-                "primitive_type": 10,
+                "primitive_type": 5,
                 "storage_type": {
                     "allocation": 0,
                     "deallocation": 0,
@@ -140,7 +140,7 @@
             "i": {
                 "alignment": 0,
                 "initializer": "",
-                "primitive_type": 10,
+                "primitive_type": 5,
                 "storage_type": {
                     "allocation": 0,
                     "deallocation": 0,
@@ -151,7 +151,7 @@
             "i_tile0": {
                 "alignment": 0,
                 "initializer": "",
-                "primitive_type": 10,
+                "primitive_type": 5,
                 "storage_type": {
                     "allocation": 0,
                     "deallocation": 0,
@@ -162,7 +162,7 @@
             "j": {
                 "alignment": 0,
                 "initializer": "",
-                "primitive_type": 10,
+                "primitive_type": 5,
                 "storage_type": {
                     "allocation": 0,
                     "deallocation": 0,
@@ -173,7 +173,7 @@
             "j_tile0": {
                 "alignment": 0,
                 "initializer": "",
-                "primitive_type": 10,
+                "primitive_type": 5,
                 "storage_type": {
                     "allocation": 0,
                     "deallocation": 0,
@@ -184,7 +184,7 @@
             "k": {
                 "alignment": 0,
                 "initializer": "",
-                "primitive_type": 10,
+                "primitive_type": 5,
                 "storage_type": {
                     "allocation": 0,
                     "deallocation": 0,
@@ -195,7 +195,7 @@
             "k_tile0": {
                 "alignment": 0,
                 "initializer": "",
-                "primitive_type": 10,
+                "primitive_type": 5,
                 "storage_type": {
                     "allocation": 0,
                     "deallocation": 0,

--- a/mlir/lib/Target/SDFG/SDFGTranslator.cpp
+++ b/mlir/lib/Target/SDFG/SDFGTranslator.cpp
@@ -37,6 +37,7 @@
 #include "sdfg/types/scalar.h"
 #include "sdfg/types/tensor.h"
 #include "sdfg/types/type.h"
+#include "sdfg/types/utils.h"
 
 namespace mlir {
 namespace sdfg {
@@ -583,12 +584,14 @@ std::string SDFGTranslator::store_in_c_order(
 
     for (size_t i = 0; i < tensor_info.shape().size(); i++) {
         std::string indvar_str = builder_.find_new_name("_i");
-        builder_.add_container(indvar_str, ::sdfg::types::Scalar(::sdfg::types::PrimitiveType::UInt64));
+        auto dim = ::sdfg::symbolic::integer(tensor_info.shape()[i]);
+        builder_
+            .add_container(indvar_str, ::sdfg::types::Scalar(::sdfg::types::get_primitive_type_to_hold_upper_bound(dim)));
 
         auto indvar = ::sdfg::symbolic::symbol(indvar_str);
         auto init = ::sdfg::symbolic::zero();
         auto update = ::sdfg::symbolic::add(indvar, ::sdfg::symbolic::one());
-        auto condition = ::sdfg::symbolic::Lt(indvar, ::sdfg::symbolic::integer(tensor_info.shape()[i]));
+        auto condition = ::sdfg::symbolic::Lt(indvar, dim);
 
         auto& loop =
             builder_
@@ -634,12 +637,14 @@ void SDFGTranslator::copy_to_output(
 
     for (size_t i = 0; i < tensor_info.shape().size(); i++) {
         std::string indvar_str = builder_.find_new_name("_i");
-        builder_.add_container(indvar_str, ::sdfg::types::Scalar(::sdfg::types::PrimitiveType::UInt64));
+        auto dim = ::sdfg::symbolic::integer(tensor_info.shape()[i]);
+        builder_
+            .add_container(indvar_str, ::sdfg::types::Scalar(::sdfg::types::get_primitive_type_to_hold_upper_bound(dim)));
 
         auto indvar = ::sdfg::symbolic::symbol(indvar_str);
         auto init = ::sdfg::symbolic::zero();
         auto update = ::sdfg::symbolic::add(indvar, ::sdfg::symbolic::one());
-        auto condition = ::sdfg::symbolic::Lt(indvar, ::sdfg::symbolic::integer(tensor_info.shape()[i]));
+        auto condition = ::sdfg::symbolic::Lt(indvar, dim);
 
         auto& loop =
             builder_

--- a/opt/src/targets/cuda/math/tensor/concat_expander.cpp
+++ b/opt/src/targets/cuda/math/tensor/concat_expander.cpp
@@ -14,6 +14,7 @@
 #include "sdfg/symbolic/symbolic.h"
 #include "sdfg/types/scalar.h"
 #include "sdfg/types/type.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg {
 namespace offloading {
@@ -37,7 +38,6 @@ bool CudaConcatExpander::expand_concat_separately(
     int parent_block_index = parent_sequence->index(*parent_block);
     auto& new_sequence = builder.add_sequence_before(*parent_sequence, *parent_block, parent_block->debug_info());
 
-    types::Scalar indvar_type(types::PrimitiveType::UInt64);
     size_t num_tensors = node.inputs().size() - 1;
     const auto* iedge_result = dfg.in_edge_for_connector(node, node.result());
     if (!iedge_result) {
@@ -52,7 +52,7 @@ bool CudaConcatExpander::expand_concat_separately(
         subset.reserve(node.tensor_layouts()[i].dims());
         for (auto dim : node.tensor_layouts()[i].shape()) {
             auto indvar_container = builder.find_new_name("_i");
-            builder.add_container(indvar_container, indvar_type);
+            builder.add_container(indvar_container, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
             auto indvar = symbolic::symbol(indvar_container);
             subset.push_back(indvar);
             auto& map = builder.add_map(

--- a/opt/src/transformations/in_local_storage.cpp
+++ b/opt/src/transformations/in_local_storage.cpp
@@ -22,6 +22,7 @@
 #include "sdfg/types/array.h"
 #include "sdfg/types/pointer.h"
 #include "sdfg/types/scalar.h"
+#include "sdfg/types/utils.h"
 
 
 namespace sdfg {
@@ -470,7 +471,7 @@ void InLocalStorage::apply(builder::StructuredSDFGBuilder& builder, analysis::An
 
         // 2. Cooperative copy: for (idx = coop_flat; idx < varying_flat_size; idx += total_coop_threads)
         auto idx_name = builder.find_new_name("__daisy_ils_coop_" + this->container_);
-        types::Scalar idx_type(types::PrimitiveType::UInt64);
+        types::Scalar idx_type(types::get_primitive_type_to_hold_upper_bound(varying_flat_size));
         builder.add_container(idx_name, idx_type);
         auto idx_var = symbolic::symbol(idx_name);
 
@@ -541,13 +542,14 @@ void InLocalStorage::apply(builder::StructuredSDFGBuilder& builder, analysis::An
         for (size_t i = 0; i < varying_dims.size(); i++) {
             size_t d = varying_dims[i];
             auto indvar_name = builder.find_new_name("__daisy_ils_" + this->container_ + "_d" + std::to_string(d));
-            types::Scalar indvar_type(types::PrimitiveType::UInt64);
+            auto& dim = varying_dim_sizes[i];
+            types::Scalar indvar_type(types::get_primitive_type_to_hold_upper_bound(dim));
             builder.add_container(indvar_name, indvar_type);
             auto indvar = symbolic::symbol(indvar_name);
             copy_indvars.push_back(indvar);
 
             auto init = symbolic::integer(0);
-            auto condition = symbolic::Lt(indvar, varying_dim_sizes[i]);
+            auto condition = symbolic::Lt(indvar, dim);
             auto update = symbolic::add(indvar, symbolic::integer(1));
 
             auto& copy_loop = builder.add_map(

--- a/opt/src/transformations/out_local_storage.cpp
+++ b/opt/src/transformations/out_local_storage.cpp
@@ -22,6 +22,7 @@
 #include "sdfg/types/array.h"
 #include "sdfg/types/pointer.h"
 #include "sdfg/types/scalar.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg {
 namespace transformations {
@@ -486,7 +487,7 @@ void OutLocalStorage::apply(builder::StructuredSDFGBuilder& builder, analysis::A
 
             // Cooperative copy-in loop
             auto idx_name = builder.find_new_name("__daisy_ols_coop_init_" + this->container_);
-            types::Scalar idx_type(types::PrimitiveType::UInt64);
+            types::Scalar idx_type(types::get_primitive_type_to_hold_upper_bound(varying_flat_size));
             builder.add_container(idx_name, idx_type);
             auto idx_var = symbolic::symbol(idx_name);
 
@@ -525,7 +526,7 @@ void OutLocalStorage::apply(builder::StructuredSDFGBuilder& builder, analysis::A
 
             // Cooperative writeback loop
             auto idx_name = builder.find_new_name("__daisy_ols_coop_wb_" + this->container_);
-            types::Scalar idx_type(types::PrimitiveType::UInt64);
+            types::Scalar idx_type(types::get_primitive_type_to_hold_upper_bound(varying_flat_size));
             builder.add_container(idx_name, idx_type);
             auto idx_var = symbolic::symbol(idx_name);
 
@@ -569,7 +570,7 @@ void OutLocalStorage::apply(builder::StructuredSDFGBuilder& builder, analysis::A
                 size_t d = varying_dims[i];
                 auto indvar_name =
                     builder.find_new_name("__daisy_ols_init_" + this->container_ + "_d" + std::to_string(d));
-                types::Scalar indvar_type(types::PrimitiveType::UInt64);
+                types::Scalar indvar_type(types::get_primitive_type_to_hold_upper_bound(varying_dim_sizes[i]));
                 builder.add_container(indvar_name, indvar_type);
                 auto indvar = symbolic::symbol(indvar_name);
                 init_indvars.push_back(indvar);
@@ -618,7 +619,7 @@ void OutLocalStorage::apply(builder::StructuredSDFGBuilder& builder, analysis::A
                 size_t d = varying_dims[i];
                 auto indvar_name =
                     builder.find_new_name("__daisy_ols_wb_" + this->container_ + "_d" + std::to_string(d));
-                types::Scalar indvar_type(types::PrimitiveType::UInt64);
+                types::Scalar indvar_type(types::get_primitive_type_to_hold_upper_bound(varying_dim_sizes[i]));
                 builder.add_container(indvar_name, indvar_type);
                 auto indvar = symbolic::symbol(indvar_name);
                 wb_indvars.push_back(indvar);

--- a/opt/tests/fixtures/polybench.h
+++ b/opt/tests/fixtures/polybench.h
@@ -56,7 +56,7 @@ inline std::unique_ptr<StructuredSDFG> correlation() {
 
     builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     builder.add_container("M", desc_symbols, true);
     builder.add_container("N", desc_symbols, true);
     builder.add_container("i", desc_symbols);
@@ -166,7 +166,7 @@ inline std::unique_ptr<StructuredSDFG> covariance() {
 
     builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     builder.add_container("M", desc_symbols, true);
     builder.add_container("N", desc_symbols, true);
     builder.add_container("i", desc_symbols);
@@ -276,7 +276,7 @@ inline std::unique_ptr<StructuredSDFG> gemm() {
     builder.add_container("B", desc_2d, true);
     builder.add_container("C", desc_2d, true);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     builder.add_container("N", desc_symbols, true);
     builder.add_container("M", desc_symbols, true);
     builder.add_container("K", desc_symbols, true);
@@ -381,7 +381,7 @@ inline std::unique_ptr<StructuredSDFG> symm() {
 
     builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     builder.add_container("i", desc_symbols);
     builder.add_container("j", desc_symbols);
     builder.add_container("k", desc_symbols);
@@ -503,7 +503,7 @@ inline std::unique_ptr<StructuredSDFG> gemver() {
 
     builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     builder.add_container("i_1", desc_symbols);
     builder.add_container("i_2", desc_symbols);
     builder.add_container("i_3", desc_symbols);
@@ -693,7 +693,7 @@ inline std::unique_ptr<StructuredSDFG> gesummv() {
 
     builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     builder.add_container("i", desc_symbols);
     builder.add_container("j", desc_symbols);
     builder.add_container("N", desc_symbols, true);
@@ -808,7 +808,7 @@ inline std::unique_ptr<StructuredSDFG> syr2k() {
 
     builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     builder.add_container("M", desc_symbols, true);
     builder.add_container("N", desc_symbols, true);
     builder.add_container("i", desc_symbols);
@@ -932,7 +932,7 @@ inline std::unique_ptr<StructuredSDFG> syrk() {
 
     builder::StructuredSDFGBuilder sdfg("sdfg_1", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     sdfg.add_container("M", desc_symbols, true);
     sdfg.add_container("N", desc_symbols, true);
     sdfg.add_container("i", desc_symbols);
@@ -1034,7 +1034,7 @@ inline std::unique_ptr<StructuredSDFG> trmm() {
 
     builder::StructuredSDFGBuilder sdfg("sdfg_1", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     sdfg.add_container("M", desc_symbols, true);
     sdfg.add_container("N", desc_symbols, true);
     sdfg.add_container("i", desc_symbols);
@@ -1129,7 +1129,7 @@ inline std::unique_ptr<StructuredSDFG> atax() {
 
     builder::StructuredSDFGBuilder sdfg("sdfg_1", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     sdfg.add_container("M", desc_symbols, true);
     sdfg.add_container("N", desc_symbols, true);
     sdfg.add_container("i_1", desc_symbols);
@@ -1249,7 +1249,7 @@ inline std::unique_ptr<StructuredSDFG> bicg() {
 
     builder::StructuredSDFGBuilder sdfg("sdfg_1", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     sdfg.add_container("M", desc_symbols, true);
     sdfg.add_container("N", desc_symbols, true);
     sdfg.add_container("i_1", desc_symbols);
@@ -1362,7 +1362,7 @@ inline std::unique_ptr<StructuredSDFG> doitgen() {
 
     builder::StructuredSDFGBuilder sdfg("sdfg_1", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     sdfg.add_container("NP", desc_symbols, true);
     sdfg.add_container("NQ", desc_symbols, true);
     sdfg.add_container("NR", desc_symbols, true);
@@ -1484,7 +1484,7 @@ inline std::unique_ptr<StructuredSDFG> mvt() {
 
     builder::StructuredSDFGBuilder sdfg("sdfg_1", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     sdfg.add_container("N", desc_symbols, true);
     sdfg.add_container("i_1", desc_symbols);
     sdfg.add_container("i_2", desc_symbols);
@@ -1588,7 +1588,7 @@ inline std::unique_ptr<StructuredSDFG> cholesky() {
 
     builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     builder.add_container("N", desc_symbols, true);
     builder.add_container("i", desc_symbols);
     builder.add_container("j", desc_symbols);
@@ -1747,7 +1747,7 @@ inline std::unique_ptr<StructuredSDFG> fdtd_2d() {
 
     builder::StructuredSDFGBuilder builder("fdtd_2d", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     builder.add_container("TMAX", desc_symbols, true);
     builder.add_container("NX", desc_symbols, true);
     builder.add_container("NY", desc_symbols, true);
@@ -1997,7 +1997,7 @@ inline std::unique_ptr<StructuredSDFG> jacobi_2d() {
 
     builder::StructuredSDFGBuilder builder("jacobi_2d", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     builder.add_container("TSTEPS", desc_symbols, true);
     builder.add_container("N", desc_symbols, true);
     builder.add_container("t", desc_symbols);

--- a/opt/tests/optimizations/blocking_test.cpp
+++ b/opt/tests/optimizations/blocking_test.cpp
@@ -19,6 +19,7 @@
 #include "sdfg/transformations/loop_split.h"
 #include "sdfg/transformations/loop_tiling.h"
 #include "sdfg/transformations/out_local_storage.h"
+#include "sdfg_debug_dump.h"
 
 using namespace sdfg;
 
@@ -82,7 +83,7 @@ struct GEMMFixture {
     void build() {
         builder = std::make_unique<builder::StructuredSDFGBuilder>("gemm", FunctionType_CPU);
 
-        types::Scalar sym_desc(types::PrimitiveType::UInt64);
+        types::Scalar sym_desc(types::PrimitiveType::Int64);
         builder->add_container("M", sym_desc, true);
         builder->add_container("N", sym_desc, true);
         builder->add_container("K", sym_desc, true);
@@ -673,7 +674,7 @@ struct GEMVFixture {
     void build() {
         builder = std::make_unique<builder::StructuredSDFGBuilder>("gemv", FunctionType_CPU);
 
-        types::Scalar sym_desc(types::PrimitiveType::UInt64);
+        types::Scalar sym_desc(types::PrimitiveType::Int64);
         builder->add_container("M", sym_desc, true);
         builder->add_container("N", sym_desc, true);
         builder->add_container("i", sym_desc);
@@ -839,7 +840,7 @@ struct LUFixture {
     void build() {
         builder = std::make_unique<builder::StructuredSDFGBuilder>("lu", FunctionType_CPU);
 
-        types::Scalar sym_desc(types::PrimitiveType::UInt64);
+        types::Scalar sym_desc(types::PrimitiveType::Int64);
         builder->add_container("N", sym_desc, true);
         builder->add_container("i", sym_desc);
         builder->add_container("j", sym_desc);
@@ -1076,6 +1077,7 @@ TEST(BlockingTest, LU_BlockedPipeline) {
     // A[i, <i_tile+B] cells, so MLA + LCDA correctly conclude no carried
     // RAW spans piece 2 with pieces 0/1.
     // -----------------------------------------------------------------------
+    dump_sdfg(builder.subject(), "lu_blocked_pipeline_before_distribution");
     transformations::LoopDistribute distribute(*i_inner, *j2_trailing);
     EXPECT_TRUE(distribute.can_be_applied(builder, am));
     recorder.apply<transformations::LoopDistribute>(builder, am, false, *i_inner, *j2_trailing);

--- a/opt/tests/optimizations/blocking_test.cpp
+++ b/opt/tests/optimizations/blocking_test.cpp
@@ -841,7 +841,8 @@ struct LUFixture {
         builder = std::make_unique<builder::StructuredSDFGBuilder>("lu", FunctionType_CPU);
 
         types::Scalar sym_desc(types::PrimitiveType::Int64);
-        builder->add_container("N", sym_desc, true);
+        types::Scalar usym_desc(types::PrimitiveType::UInt64);
+        builder->add_container("N", usym_desc, true);
         builder->add_container("i", sym_desc);
         builder->add_container("j", sym_desc);
         builder->add_container("k", sym_desc);

--- a/opt/tests/optimizations/diamond_tiling_test.cpp
+++ b/opt/tests/optimizations/diamond_tiling_test.cpp
@@ -20,6 +20,8 @@
 #include "sdfg/types/pointer.h"
 #include "sdfg_debug_dump.h"
 
+namespace diamond_tiling_test {
+
 using namespace sdfg;
 
 /**
@@ -51,7 +53,7 @@ struct Jacobi1DFixture {
     void build() {
         builder = std::make_unique<builder::StructuredSDFGBuilder>("jacobi_1d", FunctionType_CPU);
 
-        types::Scalar sym_desc(types::PrimitiveType::UInt64);
+        types::Scalar sym_desc(types::PrimitiveType::Int64);
         builder->add_container("TSTEPS", sym_desc, true);
         builder->add_container("N", sym_desc, true);
         builder->add_container("t", sym_desc);
@@ -302,7 +304,7 @@ struct Jacobi2DFixture {
     void build() {
         builder = std::make_unique<builder::StructuredSDFGBuilder>("jacobi_2d", FunctionType_CPU);
 
-        types::Scalar sym_desc(types::PrimitiveType::UInt64);
+        types::Scalar sym_desc(types::PrimitiveType::Int64);
         builder->add_container("TSTEPS", sym_desc, true);
         builder->add_container("N", sym_desc, true);
         builder->add_container("t", sym_desc);
@@ -680,7 +682,7 @@ struct FDTD2DFixture {
     void build() {
         builder = std::make_unique<builder::StructuredSDFGBuilder>("fdtd_2d", FunctionType_CPU);
 
-        types::Scalar sym_desc(types::PrimitiveType::UInt64);
+        types::Scalar sym_desc(types::PrimitiveType::Int64);
         builder->add_container("TMAX", sym_desc, true);
         builder->add_container("NX", sym_desc, true);
         builder->add_container("NY", sym_desc, true);
@@ -1143,3 +1145,5 @@ TEST(DiamondTilingTest, FDTD2D_2DSpatial) {
     // Inner t should have two maps
     ASSERT_EQ(final_t->root().size(), 2);
 }
+
+} // namespace diamond_tiling_test

--- a/opt/tests/passes/normalization/loop_normal_form_test.cpp
+++ b/opt/tests/passes/normalization/loop_normal_form_test.cpp
@@ -29,7 +29,7 @@ static void add_simple_body(
 TEST(LoopNormalFormTest, ShiftsNonZeroInit) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -78,7 +78,7 @@ TEST(LoopNormalFormTest, ShiftsNonZeroInit) {
 TEST(LoopNormalFormTest, NormalizesNonUnitStride) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -128,7 +128,7 @@ TEST(LoopNormalFormTest, NormalizesNonUnitStride) {
 TEST(LoopNormalFormTest, RotatesNegativeStride) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -173,7 +173,7 @@ TEST(LoopNormalFormTest, RotatesNegativeStride) {
 TEST(LoopNormalFormTest, AlreadyNormalized) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -228,7 +228,7 @@ TEST(LoopNormalFormTest, AlreadyNormalized) {
 TEST(LoopNormalFormTest, FullPipelinePositiveStride) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -336,7 +336,7 @@ TEST(LoopNormalFormTest, FullPipelineNegativeNonUnitStride) {
 TEST(LoopNormalFormTest, MapLoopNormalization) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -386,7 +386,7 @@ TEST(LoopNormalFormTest, MapLoopNormalization) {
 TEST(LoopNormalFormTest, NestedLoops) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
     builder.add_container("j", sym_desc);
 
@@ -464,7 +464,7 @@ TEST(LoopNormalFormTest, NestedLoops) {
 TEST(LoopNormalFormTest, SymbolicBounds) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 

--- a/opt/tests/passes/normalization/map_fusion_test.cpp
+++ b/opt/tests/passes/normalization/map_fusion_test.cpp
@@ -16,7 +16,7 @@ TEST(MapFusionPassTest, DoesNotCrashOnEmptyNestedProducerBody) {
     builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("M", sym_desc, true);
     builder.add_container("i", sym_desc);
@@ -80,7 +80,7 @@ TEST(MapFusionPassTest, PipelineStableAfterFusion) {
     builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("_s0", sym_desc, true);
     builder.add_container("_s1", sym_desc, true);
     builder.add_container("_i4", sym_desc);
@@ -181,7 +181,7 @@ TEST(MapFusionPassTest, DoesNotCrashOnEmptyNestedConsumerBody) {
     builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("M", sym_desc, true);
     builder.add_container("i", sym_desc);

--- a/opt/tests/passes/scheduler/cuda_scheduler_test.cpp
+++ b/opt/tests/passes/scheduler/cuda_scheduler_test.cpp
@@ -24,7 +24,7 @@ TEST(CUDASchedulerTest, OuterParallelMapWithInnerMap) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar base_desc(types::PrimitiveType::Float);
     types::Array desc_1(base_desc, symbolic::symbol("M"));
     types::Pointer desc_2(desc_1);
@@ -90,7 +90,7 @@ TEST(CUDASchedulerTest, OuterSequentialForWith2DMap) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar base_desc(types::PrimitiveType::Float);
     types::Array desc_1(base_desc, symbolic::symbol("M"));
     types::Pointer desc_2(desc_1);
@@ -162,7 +162,7 @@ TEST(CUDASchedulerTest, OuterWhileWithInnerMaps) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar base_desc(types::PrimitiveType::Float);
     types::Pointer desc_2(base_desc);
 
@@ -245,7 +245,7 @@ TEST(CUDASchedulerTest, NoDoubleSchedulingOfAlreadyCUDAMaps) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar base_desc(types::PrimitiveType::Float);
     types::Pointer desc_2(base_desc);
 
@@ -366,7 +366,7 @@ TEST(CUDASchedulerTest, MultipleTargetsNoDoubleScheduling) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar base_desc(types::PrimitiveType::Float);
     types::Pointer desc_2(base_desc);
 
@@ -450,7 +450,7 @@ TEST(CUDASchedulerTest, NoDoubleSchedulingOfCUDAMaps) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar base_desc(types::PrimitiveType::Float);
     types::Pointer desc_2(base_desc);
 
@@ -585,7 +585,7 @@ TEST(CUDASchedulerTest, DISABLED_OuterParallelMapWithInnerReduce) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar base_desc(types::PrimitiveType::Float);
     types::Array desc_1(base_desc, symbolic::symbol("M"));
     types::Pointer desc_2(desc_1);
@@ -653,7 +653,7 @@ TEST(CUDASchedulerTest, SkipsLoneAlreadyCUDAScheduledMap) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar base_desc(types::PrimitiveType::Float);
     types::Pointer desc_2(base_desc);
     types::Pointer opaque_desc;

--- a/opt/tests/passes/scheduler/omp_scheduler_test.cpp
+++ b/opt/tests/passes/scheduler/omp_scheduler_test.cpp
@@ -19,7 +19,7 @@ TEST(OMPSchedulerTest, OuterParallelMapWithInnerMap) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar base_desc(types::PrimitiveType::Float);
     types::Array desc_1(base_desc, symbolic::symbol("M"));
     types::Pointer desc_2(desc_1);
@@ -88,7 +88,7 @@ TEST(OMPSchedulerTest, OuterWhileWith2DMap) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar base_desc(types::PrimitiveType::Float);
     types::Array desc_1(base_desc, symbolic::symbol("M"));
     types::Pointer desc_2(desc_1);
@@ -164,7 +164,7 @@ TEST(OMPSchedulerTest, OuterWhileWithInnerMaps) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar base_desc(types::PrimitiveType::Float);
     types::Pointer desc_2(base_desc);
 
@@ -246,7 +246,7 @@ TEST(OMPSchedulerTest, SkipsAlreadyParallelMap) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar base_desc(types::PrimitiveType::Float);
     types::Pointer desc_2(base_desc);
     types::Pointer opaque_desc;

--- a/opt/tests/passes/scheduler/rocm_scheduler_test.cpp
+++ b/opt/tests/passes/scheduler/rocm_scheduler_test.cpp
@@ -23,7 +23,7 @@ TEST(ROCMSchedulerTest, SkipsLoneAlreadyROCMScheduledMap) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar base_desc(types::PrimitiveType::Float);
     types::Pointer desc_2(base_desc);
     types::Pointer opaque_desc;

--- a/opt/tests/passes/scheduler/vectorize_scheduler_test.cpp
+++ b/opt/tests/passes/scheduler/vectorize_scheduler_test.cpp
@@ -21,7 +21,7 @@ TEST(VectorizeSchedulerTest, SkipsAlreadyVectorizedMap) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar base_desc(types::PrimitiveType::Float);
     types::Pointer desc_2(base_desc);
     types::Pointer opaque_desc;

--- a/opt/tests/passes/tiling_pass_test.cpp
+++ b/opt/tests/passes/tiling_pass_test.cpp
@@ -18,7 +18,7 @@ void add_containers(builder::StructuredSDFGBuilder& builder, const std::string& 
         types::Pointer opaque_desc;
         builder.add_container("A", opaque_desc, true);
     }
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container(indvar, sym_desc);
 }
 

--- a/opt/tests/transformations/in_local_storage_test.cpp
+++ b/opt/tests/transformations/in_local_storage_test.cpp
@@ -35,7 +35,7 @@ TEST(InLocalStorageTest, For_Array) {
     builder::StructuredSDFGBuilder builder("ils_dynamic_test", FunctionType_CPU);
 
     // Create containers
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Float);
@@ -158,7 +158,7 @@ TEST(InLocalStorageTest, For_Array_Linearized) {
     builder::StructuredSDFGBuilder builder("ils_cpu_flatptr", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar loop_var(types::PrimitiveType::UInt64);
+    types::Scalar loop_var(types::PrimitiveType::Int64);
     types::Scalar elem(types::PrimitiveType::Float);
     types::Pointer ptr(elem);
     types::Pointer opaque_ptr;
@@ -283,7 +283,7 @@ TEST(InLocalStorageTest, For_Array_Linearized) {
 TEST(InLocalStorageTest, For_Array_PolyBench) {
     builder::StructuredSDFGBuilder builder("ols_flat_2d", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
     builder.add_container("j", sym_desc);
 
@@ -448,7 +448,7 @@ TEST(InLocalStorageTest, For_Scalar) {
     builder::StructuredSDFGBuilder builder("ils_dynamic_test", FunctionType_CPU);
 
     // Create containers
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Float);
@@ -564,7 +564,7 @@ TEST(InLocalStorageTest, Map_Array) {
     builder::StructuredSDFGBuilder builder("ils_dynamic_test", FunctionType_CPU);
 
     // Create containers
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Float);
@@ -693,7 +693,7 @@ TEST(InLocalStorageTest, Map_Array) {
 TEST(InLocalStorageTest, For_MultipleGroups) {
     builder::StructuredSDFGBuilder builder("ils_syr2k_seq_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar elem_desc(types::PrimitiveType::Float);
     types::Pointer ptr_desc(elem_desc);
     types::Pointer opaque_desc;
@@ -882,7 +882,7 @@ TEST(InLocalStorageTest, For_MultipleGroups) {
 TEST(InLocalStorageTest, For_MultipleGroups_SplitNode) {
     builder::StructuredSDFGBuilder builder("ils_syr2k_seq_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar elem_desc(types::PrimitiveType::Float);
     types::Pointer ptr_desc(elem_desc);
     types::Pointer opaque_desc;
@@ -1103,7 +1103,7 @@ TEST(InLocalStorageTest, For_MultipleGroups_SplitNode) {
 TEST(InLocalStorageTest, FailsOnWrittenContainer) {
     builder::StructuredSDFGBuilder builder("ils_rw_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Float);
@@ -1145,7 +1145,7 @@ TEST(InLocalStorageTest, FailsOnWrittenContainer) {
 TEST(InLocalStorageTest, FailsOnAccessOutsideLoop) {
     builder::StructuredSDFGBuilder builder("ils_outside_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Float);
@@ -1195,7 +1195,7 @@ TEST(InLocalStorageTest, FailsOnAccessOutsideLoop) {
 TEST(InLocalStorageTest, FailsOnUnusedContainer) {
     builder::StructuredSDFGBuilder builder("ils_unused_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Float);
@@ -1246,7 +1246,7 @@ TEST(InLocalStorageTest, FailsOnUnusedContainer) {
 TEST(InLocalStorageTest, JsonSerialization) {
     builder::StructuredSDFGBuilder builder("ils_json_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Float);
@@ -1319,7 +1319,7 @@ TEST(InLocalStorageTest, JsonSerialization) {
 TEST(InLocalStorageTest, TiledAccess_2D) {
     builder::StructuredSDFGBuilder builder("ils_2d_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("M", sym_desc, true);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i_tile", sym_desc);
@@ -1459,7 +1459,7 @@ TEST(InLocalStorageTest, TiledAccess_2D) {
 TEST(InLocalStorageTest, TiledAccess_1D) {
     builder::StructuredSDFGBuilder builder("ils_tiled_1d_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i_tile", sym_desc);
     builder.add_container("i", sym_desc);
@@ -1556,7 +1556,7 @@ TEST(InLocalStorageTest, TiledAccess_1D) {
 TEST(InLocalStorageTest, TiledAccess_2D_Panel) {
     builder::StructuredSDFGBuilder builder("ils_tiled_2d_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("M", sym_desc, true);
     builder.add_container("K", sym_desc, true);
     builder.add_container("i_tile", sym_desc);
@@ -1705,7 +1705,7 @@ TEST(InLocalStorageTest, TiledAccess_2D_Panel) {
 TEST(InLocalStorageTest, TiledStencil_2D_5Point) {
     builder::StructuredSDFGBuilder builder("ils_tiled_stencil_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("M", sym_desc, true);
     builder.add_container("i_tile", sym_desc);

--- a/opt/tests/transformations/loop_condition_normalize_test.cpp
+++ b/opt/tests/transformations/loop_condition_normalize_test.cpp
@@ -24,7 +24,7 @@ using namespace sdfg;
 TEST(LoopConditionNormalizeTest, PositiveStrideUnequality) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -90,7 +90,7 @@ TEST(LoopConditionNormalizeTest, PositiveStrideUnequality) {
 TEST(LoopConditionNormalizeTest, NegativeStrideUnequality) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -156,7 +156,7 @@ TEST(LoopConditionNormalizeTest, NegativeStrideUnequality) {
 TEST(LoopConditionNormalizeTest, AffineCondition) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -218,7 +218,7 @@ TEST(LoopConditionNormalizeTest, AffineCondition) {
 TEST(LoopConditionNormalizeTest, NonUnitStride_NotApplicable) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -251,7 +251,7 @@ TEST(LoopConditionNormalizeTest, NonUnitStride_NotApplicable) {
 TEST(LoopConditionNormalizeTest, NoUnequality_NotApplicable) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -284,7 +284,7 @@ TEST(LoopConditionNormalizeTest, NoUnequality_NotApplicable) {
 TEST(LoopConditionNormalizeTest, MapUnequality) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -342,7 +342,7 @@ TEST(LoopConditionNormalizeTest, MapUnequality) {
 TEST(LoopConditionNormalizeTest, IndvarOnRHS) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -392,7 +392,7 @@ TEST(LoopConditionNormalizeTest, IndvarOnRHS) {
 TEST(LoopConditionNormalizeTest, AffineIndvarExpression_NotApplicable) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -437,7 +437,7 @@ TEST(LoopConditionNormalizeTest, AffineIndvarExpression_NotApplicable) {
 TEST(LoopConditionNormalizeTest, BooleanComparisonFalseEqRelational) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("M", sym_desc, true);
     builder.add_container("i", sym_desc);
@@ -488,7 +488,7 @@ TEST(LoopConditionNormalizeTest, BooleanComparisonFalseEqRelational) {
 TEST(LoopConditionNormalizeTest, MaxBoundSimplification) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 

--- a/opt/tests/transformations/loop_indvar_finalize_test.cpp
+++ b/opt/tests/transformations/loop_indvar_finalize_test.cpp
@@ -21,7 +21,7 @@ using namespace sdfg;
 TEST(LoopIndvarFinalizeTest, AfterLoopShift) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -91,7 +91,7 @@ TEST(LoopIndvarFinalizeTest, AfterLoopShift) {
 TEST(LoopIndvarFinalizeTest, AfterLoopShiftAndUnitStride) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -167,7 +167,7 @@ TEST(LoopIndvarFinalizeTest, AfterLoopShiftAndUnitStride) {
 TEST(LoopIndvarFinalizeTest, CanApplyToNormalizedLoop) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     auto& root = builder.subject().root();
@@ -217,7 +217,7 @@ TEST(LoopIndvarFinalizeTest, CanApplyToNormalizedLoop) {
 TEST(LoopIndvarFinalizeTest, CannotApplyNotNormalForm) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     auto& root = builder.subject().root();

--- a/opt/tests/transformations/loop_peeling_test.cpp
+++ b/opt/tests/transformations/loop_peeling_test.cpp
@@ -5,6 +5,7 @@
 #include "sdfg/analysis/analysis.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
 #include "sdfg/structured_control_flow/if_else.h"
+#include "sdfg_debug_dump.h"
 
 using namespace sdfg;
 
@@ -20,7 +21,7 @@ static builder::StructuredSDFGBuilder make_compound_loop(structured_control_flow
     types::Pointer opaque_desc;
     builder.add_container("A", opaque_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("M", sym_desc, true);
     builder.add_container("i", sym_desc);
@@ -56,7 +57,7 @@ static builder::StructuredSDFGBuilder make_nested_loops(structured_control_flow:
     types::Pointer desc(base_desc);
     types::Pointer opaque_desc;
     builder.add_container("A", opaque_desc, true);
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     for (auto name : {"N", "P", "Q", "i", "j"}) {
         builder.add_container(name, sym_desc);
     }
@@ -177,7 +178,7 @@ TEST(LoopPeelingTest, NotApplicableToSimpleLoop) {
 
     types::Pointer opaque_desc;
     builder.add_container("A", opaque_desc, true);
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -207,7 +208,7 @@ static builder::StructuredSDFGBuilder make_always_fits_loop(structured_control_f
     types::Pointer desc(base_desc);
     types::Pointer opaque_desc;
     builder.add_container("A", opaque_desc, true);
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("M", sym_desc, true); // unsigned => assumption M >= 0
     builder.add_container("i", sym_desc);
 
@@ -235,12 +236,15 @@ TEST(LoopPeelingTest, HoistedRemainderEliminatedWhenProvablyInBounds) {
     auto builder = make_always_fits_loop(orig);
 
     auto sdfg = builder.move();
+    dump_sdfg(*sdfg, "0.init");
     builder::StructuredSDFGBuilder b(sdfg);
     analysis::AnalysisManager am(b.subject());
 
     transformations::LoopPeeling t(*orig); // hoisted
     EXPECT_TRUE(t.can_be_applied(b, am));
     t.apply(b, am);
+
+    dump_sdfg(b.subject(), "1.peeled");
 
     auto& s = b.subject();
     ASSERT_EQ(s.root().size(), 1);
@@ -323,7 +327,7 @@ TEST(LoopPeelingTest, InnerRemainderEliminatedViaEnclosingLoopBound) {
     types::Pointer desc(base_desc);
     types::Pointer opaque_desc;
     builder.add_container("A", opaque_desc, true);
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("t", sym_desc);
     builder.add_container("i", sym_desc);
 
@@ -386,7 +390,7 @@ TEST(LoopPeelingTest, InnerRemainderEliminatedViaStrideTightBound) {
     types::Pointer desc(base_desc);
     types::Pointer opaque_desc;
     builder.add_container("A", opaque_desc, true);
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("it", sym_desc);
     builder.add_container("i", sym_desc);
 

--- a/opt/tests/transformations/loop_peeling_test.cpp
+++ b/opt/tests/transformations/loop_peeling_test.cpp
@@ -209,7 +209,8 @@ static builder::StructuredSDFGBuilder make_always_fits_loop(structured_control_f
     types::Pointer opaque_desc;
     builder.add_container("A", opaque_desc, true);
     types::Scalar sym_desc(types::PrimitiveType::Int64);
-    builder.add_container("M", sym_desc, true); // unsigned => assumption M >= 0
+    types::Scalar usym_desc(types::PrimitiveType::UInt64);
+    builder.add_container("M", usym_desc, true); // unsigned => assumption M >= 0
     builder.add_container("i", sym_desc);
 
     auto i = symbolic::symbol("i");

--- a/opt/tests/transformations/loop_rotate_test.cpp
+++ b/opt/tests/transformations/loop_rotate_test.cpp
@@ -35,7 +35,7 @@ using namespace sdfg;
 TEST(LoopRotateTest, BasicRotation) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -116,7 +116,7 @@ TEST(LoopRotateTest, BasicRotation) {
 TEST(LoopRotateTest, SymbolicBounds) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -185,7 +185,7 @@ TEST(LoopRotateTest, SymbolicBounds) {
 TEST(LoopRotateTest, NonZeroLowerBound) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -245,7 +245,7 @@ TEST(LoopRotateTest, NonZeroLowerBound) {
 TEST(LoopRotateTest, CannotApplyPositiveStride) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     auto& root = builder.subject().root();
@@ -277,7 +277,7 @@ TEST(LoopRotateTest, CannotApplyPositiveStride) {
 TEST(LoopRotateTest, CannotApplyNonUnitNegativeStride) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     auto& root = builder.subject().root();
@@ -309,7 +309,7 @@ TEST(LoopRotateTest, CannotApplyNonUnitNegativeStride) {
 TEST(LoopRotateTest, MapLoop) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -360,7 +360,7 @@ TEST(LoopRotateTest, MapLoop) {
 TEST(LoopRotateTest, WithSymbolPropagation) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -434,7 +434,7 @@ TEST(LoopRotateTest, WithSymbolPropagation) {
 TEST(LoopRotateTest, JsonRoundTrip) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     auto& root = builder.subject().root();
@@ -478,7 +478,7 @@ TEST(LoopRotateTest, JsonRoundTrip) {
 TEST(LoopRotateTest, IndvarFinalValueAfterLoop) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);

--- a/opt/tests/transformations/loop_shift_test.cpp
+++ b/opt/tests/transformations/loop_shift_test.cpp
@@ -30,7 +30,7 @@ using namespace sdfg;
 TEST(LoopShiftTest, ShiftToZero) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -105,7 +105,7 @@ TEST(LoopShiftTest, ShiftToZero) {
 TEST(LoopShiftTest, ShiftByOffset) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -169,7 +169,7 @@ TEST(LoopShiftTest, ShiftByOffset) {
 TEST(LoopShiftTest, IndvarUsedInAccessNode) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -248,7 +248,7 @@ TEST(LoopShiftTest, IndvarUsedInAccessNode) {
 TEST(LoopShiftTest, NoOpWhenOffsetIsZero) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -286,7 +286,7 @@ TEST(LoopShiftTest, NoOpWhenOffsetIsZero) {
 TEST(LoopShiftTest, IndvarFinalValueAfterLoop) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);

--- a/opt/tests/transformations/loop_split_test.cpp
+++ b/opt/tests/transformations/loop_split_test.cpp
@@ -21,7 +21,7 @@ static builder::StructuredSDFGBuilder make_simple_loop_sdfg(structured_control_f
     types::Pointer opaque_desc;
     builder.add_container("A", opaque_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -66,7 +66,7 @@ TEST(LoopSplitTest, Basic) {
     analysis::AnalysisManager analysis_manager(builder_opt.subject());
 
     // Split at symbolic point M (need to add M as a container)
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder_opt.add_container("M", sym_desc, true);
     auto split_point = symbolic::symbol("M");
 
@@ -155,7 +155,7 @@ TEST(LoopSplitTest, SplitWithNonZeroInit) {
     types::Pointer opaque_desc;
     builder.add_container("A", opaque_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("M", sym_desc, true);
     builder.add_container("K", sym_desc, true);
@@ -212,7 +212,7 @@ TEST(LoopSplitTest, Serialization) {
     structured_control_flow::For* orig_loop = nullptr;
     auto builder = make_simple_loop_sdfg(orig_loop);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("M", sym_desc, true);
 
     auto split_point = symbolic::symbol("M");
@@ -235,7 +235,7 @@ TEST(LoopSplitTest, Deserialization) {
     structured_control_flow::For* orig_loop = nullptr;
     auto builder = make_simple_loop_sdfg(orig_loop);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("M", sym_desc, true);
 
     size_t loop_id = orig_loop->element_id();
@@ -257,7 +257,7 @@ TEST(LoopSplitTest, CannotApplyNonContiguous) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 

--- a/opt/tests/transformations/loop_unit_stride_test.cpp
+++ b/opt/tests/transformations/loop_unit_stride_test.cpp
@@ -15,7 +15,7 @@ using namespace sdfg;
 TEST(LoopUnitStrideTest, BasicPositiveStride) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -86,7 +86,7 @@ TEST(LoopUnitStrideTest, BasicPositiveStride) {
 TEST(LoopUnitStrideTest, SymbolicBoundPositiveStride) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -150,7 +150,7 @@ TEST(LoopUnitStrideTest, SymbolicBoundPositiveStride) {
 TEST(LoopUnitStrideTest, CannotApplyNonZeroInit) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -259,7 +259,7 @@ TEST(LoopUnitStrideTest, NegativeStridePreservesDirection) {
 TEST(LoopUnitStrideTest, PositiveStridePreservesDirection) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -315,7 +315,7 @@ TEST(LoopUnitStrideTest, PositiveStridePreservesDirection) {
 TEST(LoopUnitStrideTest, CannotApplyUnitStride) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -356,7 +356,7 @@ TEST(LoopUnitStrideTest, CannotApplyUnitStride) {
 TEST(LoopUnitStrideTest, CannotApplyNegativeUnitStride) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -397,7 +397,7 @@ TEST(LoopUnitStrideTest, CannotApplyNegativeUnitStride) {
 TEST(LoopUnitStrideTest, MapLoop) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -450,7 +450,7 @@ TEST(LoopUnitStrideTest, MapLoop) {
 TEST(LoopUnitStrideTest, JsonRoundTrip) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -498,7 +498,7 @@ TEST(LoopUnitStrideTest, JsonRoundTrip) {
 TEST(LoopUnitStrideTest, LargeStride) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);
@@ -556,7 +556,7 @@ TEST(LoopUnitStrideTest, LargeStride) {
 TEST(LoopUnitStrideTest, IndvarFinalValueAfterLoop) {
     builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Double);

--- a/opt/tests/transformations/multi_level_tiling_test.cpp
+++ b/opt/tests/transformations/multi_level_tiling_test.cpp
@@ -22,7 +22,7 @@ TEST(MultiLevelTilingTest, TwoLevelTiling) {
     types::Pointer opaque_desc;
     builder.add_container("A", opaque_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -119,7 +119,7 @@ TEST(MultiLevelTilingTest, TwoLevelTilingSerialization) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -156,7 +156,7 @@ TEST(MultiLevelTilingTest, TwoLevelTilingInvalidParameters) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 

--- a/opt/tests/transformations/out_local_storage_test.cpp
+++ b/opt/tests/transformations/out_local_storage_test.cpp
@@ -36,7 +36,7 @@ TEST(OutLocalStorageTest, For_Array_RW) {
     builder::StructuredSDFGBuilder builder("ols_for_array_rw_test", FunctionType_CPU);
 
     // Create containers
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Float);
@@ -210,7 +210,7 @@ TEST(OutLocalStorageTest, For_Array_RW) {
 TEST(OutLocalStorageTest, For_Array_WO) {
     builder::StructuredSDFGBuilder builder("ols_for_array_wo_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Float);
@@ -329,7 +329,7 @@ TEST(OutLocalStorageTest, For_Array_Linearized_RW) {
     builder::StructuredSDFGBuilder builder("ols_cpu_flatptr_rw", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar loop_var(types::PrimitiveType::UInt64);
+    types::Scalar loop_var(types::PrimitiveType::Int64);
     types::Scalar elem(types::PrimitiveType::Float);
     types::Pointer ptr(elem);
     types::Pointer opaque_ptr;
@@ -453,7 +453,7 @@ TEST(OutLocalStorageTest, For_Array_Linearized_WO) {
     builder::StructuredSDFGBuilder builder("ols_cpu_flatptr", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar loop_var(types::PrimitiveType::UInt64);
+    types::Scalar loop_var(types::PrimitiveType::Int64);
     types::Scalar elem(types::PrimitiveType::Float);
     types::Pointer ptr(elem);
 
@@ -549,7 +549,7 @@ TEST(OutLocalStorageTest, For_Array_Linearized_WO) {
 TEST(OutLocalStorageTest, For_Array_PolyBench_WO) {
     builder::StructuredSDFGBuilder builder("ols_polybench_wo", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
     builder.add_container("j", sym_desc);
 
@@ -659,7 +659,7 @@ TEST(OutLocalStorageTest, For_Array_PolyBench_WO) {
 TEST(OutLocalStorageTest, For_Array_PolyBench_RW) {
     builder::StructuredSDFGBuilder builder("ols_flat_2d", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
     builder.add_container("j", sym_desc);
 
@@ -781,7 +781,7 @@ TEST(OutLocalStorageTest, For_Array_PolyBench_RW) {
 TEST(OutLocalStorageTest, For_Scalar_RW) {
     builder::StructuredSDFGBuilder builder("ols_for_scalar_rw_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Float);
@@ -916,7 +916,7 @@ TEST(OutLocalStorageTest, For_Scalar_RW) {
 TEST(OutLocalStorageTest, For_Scalar_WO) {
     builder::StructuredSDFGBuilder builder("ols_for_scalar_wo_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Float);
@@ -999,7 +999,7 @@ TEST(OutLocalStorageTest, For_Scalar_WO) {
 TEST(OutLocalStorageTest, Map_Array_RW) {
     builder::StructuredSDFGBuilder builder("ols_map_array_rw_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Float);
@@ -1061,7 +1061,7 @@ TEST(OutLocalStorageTest, Map_Array_RW) {
 TEST(OutLocalStorageTest, Map_Array_WO) {
     builder::StructuredSDFGBuilder builder("ols_map_array_wo_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Float);
@@ -1123,7 +1123,7 @@ TEST(OutLocalStorageTest, Map_Array_WO) {
 TEST(OutLocalStorageTest, For_MultipleGroups_RW) {
     builder::StructuredSDFGBuilder builder("ols_multi_groups_rw_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar elem_desc(types::PrimitiveType::Float);
     types::Pointer ptr_desc(elem_desc);
     types::Pointer opaque_desc;
@@ -1211,7 +1211,7 @@ TEST(OutLocalStorageTest, For_MultipleGroups_RW) {
 TEST(OutLocalStorageTest, For_MultipleGroups_WO) {
     builder::StructuredSDFGBuilder builder("ols_multi_groups_wo_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar elem_desc(types::PrimitiveType::Float);
     types::Pointer ptr_desc(elem_desc);
     types::Pointer opaque_desc;
@@ -1294,7 +1294,7 @@ TEST(OutLocalStorageTest, For_MultipleGroups_WO) {
 TEST(OutLocalStorageTest, For_MultipleGroups_SplitNode_WO) {
     builder::StructuredSDFGBuilder builder("ols_split_node_wo_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     types::Scalar elem_desc(types::PrimitiveType::Float);
     types::Pointer ptr_desc(elem_desc);
     types::Pointer opaque_desc;
@@ -1381,7 +1381,7 @@ TEST(OutLocalStorageTest, For_MultipleGroups_SplitNode_WO) {
 TEST(OutLocalStorageTest, FailsOnUnusedContainer) {
     builder::StructuredSDFGBuilder builder("ols_unused_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Float);
@@ -1429,7 +1429,7 @@ TEST(OutLocalStorageTest, FailsOnUnusedContainer) {
 TEST(OutLocalStorageTest, JsonSerialization) {
     builder::StructuredSDFGBuilder builder("ols_json_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     types::Scalar elem_desc(types::PrimitiveType::Float);
@@ -1485,7 +1485,7 @@ TEST(OutLocalStorageTest, JsonSerialization) {
 TEST(OutLocalStorageTest, FailsOnReadOnly) {
     builder::StructuredSDFGBuilder builder("ols_ro_fail", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
     builder.add_container("j", sym_desc);
 
@@ -1534,7 +1534,7 @@ TEST(OutLocalStorageTest, FailsOnReadOnly) {
 TEST(OutLocalStorageTest, FailsOnAccessOutsideLoop) {
     builder::StructuredSDFGBuilder builder("ols_outside_fail", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
     builder.add_container("j", sym_desc);
 
@@ -1612,7 +1612,7 @@ TEST(OutLocalStorageTest, FailsOnAccessOutsideLoop) {
 TEST(OutLocalStorageTest, FlatPointer_Linearized2D) {
     builder::StructuredSDFGBuilder builder("ols_flat_2d", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
     builder.add_container("j", sym_desc);
 
@@ -1726,7 +1726,7 @@ TEST(OutLocalStorageTest, FlatPointer_Linearized2D) {
 TEST(OutLocalStorageTest, TiledAccumulator_2D) {
     builder::StructuredSDFGBuilder builder("ols_tiled_2d", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("K", sym_desc, true);
     builder.add_container("i_tile", sym_desc);
@@ -1890,7 +1890,7 @@ TEST(OutLocalStorageTest, TiledAccumulator_2D) {
 TEST(OutLocalStorageTest, TiledWriteOnly_1D) {
     builder::StructuredSDFGBuilder builder("ols_tiled_wo", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i_tile", sym_desc);
     builder.add_container("i", sym_desc);
@@ -1996,7 +1996,7 @@ TEST(OutLocalStorageTest, TiledWriteOnly_1D) {
 TEST(OutLocalStorageTest, TiledAccumulator_1D_NonZeroBase) {
     builder::StructuredSDFGBuilder builder("ols_tiled_1d_base", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("M", sym_desc, true);
     builder.add_container("i_tile", sym_desc);

--- a/opt/tests/transformations/recorder_test.cpp
+++ b/opt/tests/transformations/recorder_test.cpp
@@ -31,7 +31,7 @@ protected:
         types::Pointer desc(base_desc);
         builder_->add_container("A", desc, true);
 
-        types::Scalar sym_desc(types::PrimitiveType::UInt64);
+        types::Scalar sym_desc(types::PrimitiveType::Int64);
         builder_->add_container("N", sym_desc, true);
         builder_->add_container("i", sym_desc);
 
@@ -142,7 +142,7 @@ protected:
 
         builder_->add_container("A", desc, true);
 
-        types::Scalar sym_desc(types::PrimitiveType::UInt64);
+        types::Scalar sym_desc(types::PrimitiveType::Int64);
         builder_->add_container("N", sym_desc, true);
         builder_->add_container("M", sym_desc, true);
         builder_->add_container("i", sym_desc);
@@ -364,7 +364,7 @@ protected:
 
         builder_->add_container("A", desc, true);
 
-        types::Scalar sym_desc(types::PrimitiveType::UInt64);
+        types::Scalar sym_desc(types::PrimitiveType::Int64);
         builder_->add_container("N", sym_desc, true);
         builder_->add_container("M", sym_desc, true);
         builder_->add_container("i", sym_desc);

--- a/opt/tests/transformations/tile_fusion_test.cpp
+++ b/opt/tests/transformations/tile_fusion_test.cpp
@@ -14,6 +14,8 @@
 #include "sdfg/types/array.h"
 #include "sdfg/types/scalar.h"
 
+namespace tile_fusion_test {
+
 using namespace sdfg;
 
 /**
@@ -34,7 +36,7 @@ struct Jacobi1DFixture {
     void build() {
         builder = std::make_unique<builder::StructuredSDFGBuilder>("jacobi_1d", FunctionType_CPU);
 
-        types::Scalar sym_desc(types::PrimitiveType::UInt64);
+        types::Scalar sym_desc(types::PrimitiveType::Int64);
         builder->add_container("TSTEPS", sym_desc, true);
         builder->add_container("N", sym_desc, true);
         builder->add_container("t", sym_desc);
@@ -264,7 +266,7 @@ TEST(TileFusionTest, Jacobi1D_Basic) {
 TEST(TileFusionTest, NonConsecutiveMaps_ShouldFail) {
     builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
     builder.add_container("j", sym_desc);
@@ -357,7 +359,7 @@ TEST(TileFusionTest, NonConsecutiveMaps_ShouldFail) {
 TEST(TileFusionTest, IncompatibleTileSizes_ShouldFail) {
     builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
     builder.add_container("j", sym_desc);
@@ -429,7 +431,7 @@ TEST(TileFusionTest, IncompatibleTileSizes_ShouldFail) {
 TEST(TileFusionTest, NoSharedContainer_ShouldFail) {
     builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
     builder.add_container("j", sym_desc);
@@ -503,7 +505,7 @@ TEST(TileFusionTest, NoSharedContainer_ShouldFail) {
 TEST(TileFusionTest, ConsumerAlsoWritesIntermediate_ShouldFail) {
     builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
     builder.add_container("j", sym_desc);
@@ -577,7 +579,7 @@ TEST(TileFusionTest, ZeroRadiusElementwise) {
     // Radius should be 0, but transformation should still work
     builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
     builder.add_container("j", sym_desc);
@@ -874,7 +876,7 @@ TEST(TileFusionTest, NoCyclicDependency_NoBuffers) {
     // No cyclic: K2 writes C, K1 doesn't read C.
     builder::StructuredSDFGBuilder builder("sdfg_test", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
     builder.add_container("j", sym_desc);
@@ -1021,3 +1023,5 @@ TEST(TileFusionTest, Jacobi1D_Serialization) {
     EXPECT_TRUE(tile_fusion2.can_be_applied(builder_opt, analysis_manager));
     EXPECT_EQ(tile_fusion2.radius(), 1);
 }
+
+} // namespace tile_fusion_test

--- a/opt/tests/transformations/unroll_transform_test.cpp
+++ b/opt/tests/transformations/unroll_transform_test.cpp
@@ -17,7 +17,7 @@ static builder::StructuredSDFGBuilder make_loop(structured_control_flow::For*& o
     types::Pointer desc(base_desc);
     types::Pointer opaque_desc;
     builder.add_container("A", opaque_desc, true);
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 

--- a/python/tests/sdfg/analysis/test_loop_analysis.py
+++ b/python/tests/sdfg/analysis/test_loop_analysis.py
@@ -8,6 +8,8 @@ from docc.sdfg import (
     For,
     StructuredLoop,
     ControlFlowNode,
+    PrimitiveType,
+    Scalar,
 )
 
 
@@ -30,6 +32,7 @@ class TestLoopAnalysisBasic:
     def test_loops_single_for(self):
         """Test loops() returns single loop for SDFG with one for loop."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -45,7 +48,9 @@ class TestLoopAnalysisBasic:
     def test_loops_nested_fors(self):
         """Test loops() returns all nested loops in DFS order."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
+        builder.add_container("j", Scalar(PrimitiveType.Int64))
         builder.begin_for("j", "0", "20", "1")
         builder.add_block()
         builder.end_for()
@@ -68,6 +73,7 @@ class TestLoopInfo:
     def test_loop_info_single_loop(self):
         """Test loop_info() returns correct info for a single loop."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -89,8 +95,11 @@ class TestLoopInfo:
     def test_loop_info_nested_loops(self):
         """Test loop_info() returns correct depth for nested loops."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
+        builder.add_container("j", Scalar(PrimitiveType.Int64))
         builder.begin_for("j", "0", "20", "1")
+        builder.add_container("k", Scalar(PrimitiveType.Int64))
         builder.begin_for("k", "0", "30", "1")
         builder.add_block()
         builder.end_for()
@@ -109,6 +118,7 @@ class TestLoopInfo:
     def test_loop_info_repr(self):
         """Test LoopInfo string representation."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -129,6 +139,7 @@ class TestLoopInfo:
     def test_loop_info_all_properties(self):
         """Test all LoopInfo properties are accessible."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -160,6 +171,7 @@ class TestFindLoopByIndvar:
     def test_find_existing_indvar(self):
         """Test finding a loop by existing induction variable."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -176,6 +188,7 @@ class TestFindLoopByIndvar:
     def test_find_nonexistent_indvar(self):
         """Test finding a loop by nonexistent induction variable returns None."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -190,7 +203,9 @@ class TestFindLoopByIndvar:
     def test_find_indvar_nested_loops(self):
         """Test finding loops by indvar in nested loop structure."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
+        builder.add_container("j", Scalar(PrimitiveType.Int64))
         builder.begin_for("j", "0", "20", "1")
         builder.add_block()
         builder.end_for()
@@ -216,6 +231,7 @@ class TestParentLoop:
     def test_parent_loop_outermost(self):
         """Test parent_loop() returns None for outermost loop."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -231,7 +247,9 @@ class TestParentLoop:
     def test_parent_loop_nested(self):
         """Test parent_loop() returns correct parent for nested loop."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
+        builder.add_container("j", Scalar(PrimitiveType.Int64))
         builder.begin_for("j", "0", "20", "1")
         builder.add_block()
         builder.end_for()
@@ -255,6 +273,7 @@ class TestOutermostLoops:
     def test_outermost_loops_single(self):
         """Test outermost_loops() with single outermost loop."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -270,9 +289,11 @@ class TestOutermostLoops:
     def test_outermost_loops_multiple(self):
         """Test outermost_loops() with multiple sequential loops."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
+        builder.add_container("j", Scalar(PrimitiveType.Int64))
         builder.begin_for("j", "0", "20", "1")
         builder.add_block()
         builder.end_for()
@@ -287,7 +308,9 @@ class TestOutermostLoops:
     def test_outermost_loops_nested_only_returns_outer(self):
         """Test outermost_loops() only returns outer loop for nested structure."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
+        builder.add_container("j", Scalar(PrimitiveType.Int64))
         builder.begin_for("j", "0", "20", "1")
         builder.add_block()
         builder.end_for()
@@ -304,7 +327,9 @@ class TestOutermostLoops:
     def test_is_outermost_loop(self):
         """Test is_outermost_loop() correctly identifies outermost loops."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
+        builder.add_container("j", Scalar(PrimitiveType.Int64))
         builder.begin_for("j", "0", "20", "1")
         builder.add_block()
         builder.end_for()
@@ -327,6 +352,7 @@ class TestChildrenAndDescendants:
     def test_children_empty(self):
         """Test children() returns empty list for innermost loop."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -343,7 +369,9 @@ class TestChildrenAndDescendants:
     def test_children_nested(self):
         """Test children() returns immediate child loops."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
+        builder.add_container("j", Scalar(PrimitiveType.Int64))
         builder.begin_for("j", "0", "20", "1")
         builder.add_block()
         builder.end_for()
@@ -366,6 +394,7 @@ class TestChildrenAndDescendants:
     def test_descendants_empty(self):
         """Test descendants() returns empty for innermost loop."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -382,8 +411,11 @@ class TestChildrenAndDescendants:
     def test_descendants_nested(self):
         """Test descendants() returns all descendant loops."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
+        builder.add_container("j", Scalar(PrimitiveType.Int64))
         builder.begin_for("j", "0", "20", "1")
+        builder.add_container("k", Scalar(PrimitiveType.Int64))
         builder.begin_for("k", "0", "30", "1")
         builder.add_block()
         builder.end_for()
@@ -416,6 +448,7 @@ class TestLoopTreePaths:
     def test_loop_tree_paths_single_loop(self):
         """Test loop_tree_paths() for single loop returns path with just that loop."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -436,7 +469,9 @@ class TestLoopTreePaths:
     def test_loop_tree_paths_nested(self):
         """Test loop_tree_paths() returns correct paths for nested loops."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
+        builder.add_container("j", Scalar(PrimitiveType.Int64))
         builder.begin_for("j", "0", "20", "1")
         builder.add_block()
         builder.end_for()
@@ -473,6 +508,7 @@ class TestOutermostMaps:
     def test_outermost_maps_empty_when_no_maps(self):
         """Test outermost_maps() returns empty when only For loops present."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()

--- a/python/tests/sdfg/control_flow/test_loop.py
+++ b/python/tests/sdfg/control_flow/test_loop.py
@@ -20,6 +20,7 @@ class TestStructuredLoop:
     def test_indvar_property(self):
         """Test indvar property returns the induction variable."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -34,6 +35,7 @@ class TestStructuredLoop:
     def test_init_property(self):
         """Test init property returns the initialization expression."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -48,6 +50,7 @@ class TestStructuredLoop:
     def test_update_property(self):
         """Test update property returns the update expression."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -63,6 +66,7 @@ class TestStructuredLoop:
     def test_condition_property(self):
         """Test condition property returns the loop condition."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -79,6 +83,7 @@ class TestStructuredLoop:
     def test_body_property(self):
         """Test body property returns the loop body sequence."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -94,6 +99,7 @@ class TestStructuredLoop:
         """Test parent references of structured loop"""
         builder = StructuredSDFGBuilder("test_sdfg")
 
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -112,6 +118,7 @@ class TestFor:
     def test_for_isinstance(self):
         """Test that for loop is an instance of For."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -124,6 +131,7 @@ class TestFor:
     def test_for_inherits_structured_loop(self):
         """Test that For inherits from StructuredLoop."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -136,6 +144,7 @@ class TestFor:
     def test_for_repr(self):
         """Test For string representation."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()
@@ -150,6 +159,7 @@ class TestFor:
     def test_for_with_step(self):
         """Test for loop with different step values."""
         builder = StructuredSDFGBuilder("test_sdfg")
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "100", "5")
         builder.add_block()
         builder.end_for()
@@ -166,6 +176,7 @@ class TestFor:
         builder = StructuredSDFGBuilder("test_sdfg")
         builder.add_container("n", Scalar(PrimitiveType.Int32), is_argument=True)
 
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "n", "1")
         builder.add_block()
         builder.end_for()
@@ -180,7 +191,9 @@ class TestFor:
         """Test nested for loops."""
         builder = StructuredSDFGBuilder("test_sdfg")
 
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
+        builder.add_container("j", Scalar(PrimitiveType.Int64))
         builder.begin_for("j", "0", "10", "1")
         builder.add_block()
         builder.end_for()

--- a/python/tests/sdfg/control_flow/test_sequence.py
+++ b/python/tests/sdfg/control_flow/test_sequence.py
@@ -132,6 +132,7 @@ class TestSequence:
         builder = StructuredSDFGBuilder("test_sdfg")
 
         # Create a for loop which has its own body sequence
+        builder.add_container("i", Scalar(PrimitiveType.Int64))
         builder.begin_for("i", "0", "10", "1")
         builder.add_block()
         builder.end_for()

--- a/python/tests/sdfg/passes/test_schedulers.py
+++ b/python/tests/sdfg/passes/test_schedulers.py
@@ -26,7 +26,7 @@ def _build_map_nest():
     """A 2-D elementwise map nest ``B[i, j] = A[i, j]`` (fully parallelizable)."""
     builder = StructuredSDFGBuilder("scheduler_test")
     f = Scalar(PrimitiveType.Float)
-    u = Scalar(PrimitiveType.UInt64)
+    u = Scalar(PrimitiveType.Int64)
 
     builder.add_container("N", u, is_argument=True)
     builder.add_container("M", u, is_argument=True)

--- a/python/tests/sdfg/transformations/test_collapse.py
+++ b/python/tests/sdfg/transformations/test_collapse.py
@@ -60,7 +60,7 @@ def _collapse_to_compiled(builder, outer_map, name, output_root):
 def _build_single_map():
     builder = StructuredSDFGBuilder("collapse_single_map")
     f = Scalar(PrimitiveType.Float)
-    u = Scalar(PrimitiveType.UInt64)
+    u = Scalar(PrimitiveType.Int64)
 
     builder.add_container("N", u, is_argument=True)
     builder.add_container("M", u, is_argument=True)
@@ -109,7 +109,7 @@ def test_collapse_single_map(N, M, tmp_path):
 def _build_two_maps():
     builder = StructuredSDFGBuilder("collapse_two_maps")
     f = Scalar(PrimitiveType.Float)
-    u = Scalar(PrimitiveType.UInt64)
+    u = Scalar(PrimitiveType.Int64)
 
     for name in ("N", "M", "P"):
         builder.add_container(name, u, is_argument=True)
@@ -163,7 +163,7 @@ def test_collapse_two_maps(N, M, P, tmp_path):
 def _build_block_map():
     builder = StructuredSDFGBuilder("collapse_block_map")
     f = Scalar(PrimitiveType.Float)
-    u = Scalar(PrimitiveType.UInt64)
+    u = Scalar(PrimitiveType.Int64)
 
     builder.add_container("N", u, is_argument=True)
     builder.add_container("M", u, is_argument=True)

--- a/python/tests/sdfg/transformations/test_local_storage.py
+++ b/python/tests/sdfg/transformations/test_local_storage.py
@@ -37,7 +37,7 @@ from docc.sdfg import (
 from docc.compiler.compiled_sdfg import CompiledSDFG
 
 F = Scalar(PrimitiveType.Float)
-U = Scalar(PrimitiveType.UInt64)
+U = Scalar(PrimitiveType.Int64)
 PF = Pointer(F)
 
 

--- a/rpc/tests/passes/rpc/rpc_loop_opt_test.cpp
+++ b/rpc/tests/passes/rpc/rpc_loop_opt_test.cpp
@@ -36,7 +36,7 @@ protected:
         builder_->add_container("B", desc_2, true);
         builder_->add_container("C", desc_2, true);
 
-        types::Scalar sym_desc(types::PrimitiveType::UInt64);
+        types::Scalar sym_desc(types::PrimitiveType::Int64);
         builder_->add_container("K", sym_desc, true);
         builder_->add_container("N", sym_desc, true);
         builder_->add_container("M", sym_desc, true);
@@ -231,7 +231,7 @@ protected:
         builder_->add_container("B", desc_2, true);
         builder_->add_container("C", desc_2, true);
 
-        types::Scalar sym_desc(types::PrimitiveType::UInt64);
+        types::Scalar sym_desc(types::PrimitiveType::Int64);
         builder_->add_container("K", sym_desc, true);
         builder_->add_container("N", sym_desc, true);
         builder_->add_container("M", sym_desc, true);

--- a/rpc/tests/transformations/rpc_node_transform_test.cpp
+++ b/rpc/tests/transformations/rpc_node_transform_test.cpp
@@ -49,7 +49,7 @@ protected:
         builder_->add_container("B", desc_2, true);
         builder_->add_container("C", desc_2, true);
 
-        types::Scalar sym_desc(types::PrimitiveType::UInt64);
+        types::Scalar sym_desc(types::PrimitiveType::Int64);
         builder_->add_container("K", sym_desc, true);
         builder_->add_container("N", sym_desc, true);
         builder_->add_container("M", sym_desc, true);
@@ -190,6 +190,7 @@ TEST_F(RPCNodeTransformTest, Double_Matmul) {
     auto outer_loops = loop_analysis.outermost_loops();
     EXPECT_EQ(outer_loops.size(), 2);
 
+    builder.subject().validate();
     auto outer_loop = static_cast<structured_control_flow::StructuredLoop*>(outer_loops[0]);
     sdfg::transformations::RPCNodeTransform
         transfer_tuning(*outer_loop, "sequential", "server", *ctx_, true, true, true);

--- a/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/tensor_layout.h
+++ b/sdfg/include/sdfg/data_flow/library_nodes/math/tensor/tensor_layout.h
@@ -114,8 +114,6 @@ public:
     static std::ostream& emit_symbolic_list(std::ostream& stream, const symbolic::MultiExpression& list);
 
     static types::PrimitiveType get_tensor_indvar_type_for_shape(const std::vector<symbolic::Expression>& shape);
-
-    static types::PrimitiveType get_combined_tensor_indvar_type(types::PrimitiveType a, types::PrimitiveType b);
 };
 
 std::ostream& operator<<(std::ostream& stream, const TensorLayout& layout);

--- a/sdfg/include/sdfg/types/utils.h
+++ b/sdfg/include/sdfg/types/utils.h
@@ -126,7 +126,28 @@ const types::IType* peel_to_next_element(const types::IType& type);
  */
 bool is_contiguous_type(const types::IType& type, StructuredSDFG& sdfg);
 
-PrimitiveType get_primitive_type_to_hold_expression(const symbolic::Expression& expr);
+/**
+ * Return a good primitive type that can hold the expressions maximum value.
+ * Current limited impl: will evaluate the expression. If result is immediate and fits into Int32, then that,
+ * otherwise falls back to Int64
+ * @return For now Int32 or Int64 if not sure
+ */
+PrimitiveType get_primitive_type_to_hold_upper_bound(const symbolic::Expression& expr);
+
+/**
+ * Return a good primitive type that can hold the expressions minimum value.
+ * Current limited impl: will evaluate the expression. If result is immediate and fits into Int32, then that,
+ * otherwise falls back to Int64
+ * @return For now Int32 or Int64 if not sure
+ */
+PrimitiveType get_primitive_type_to_hold_lower_bound(const symbolic::Expression& expr);
+
+/**
+ * Return the primitive type that can hold the contents of both a and b without any risk of loss
+ * (respecting C-style signed-overflow is undefined and need not be considered. but unsigned overflow does)
+ * @return
+ */
+PrimitiveType get_primitive_type_to_hold(PrimitiveType a, PrimitiveType b);
 
 } // namespace types
 } // namespace sdfg

--- a/sdfg/src/data_flow/library_nodes/math/blas/batched_gemm_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/blas/batched_gemm_node.cpp
@@ -3,6 +3,7 @@
 
 #include "sdfg/analysis/analysis.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg {
 namespace math {
@@ -238,7 +239,8 @@ passes::LibNodeExpander::ExpandOutcome BatchedGEMMNode::
 
     // Batch loop (outermost)
     std::string batch_indvar_str = builder.find_new_name("_batch");
-    builder.add_container(batch_indvar_str, types::Scalar(types::PrimitiveType::UInt64));
+    builder
+        .add_container(batch_indvar_str, types::Scalar(types::get_primitive_type_to_hold_expression(this->batch_count_)));
     auto batch_indvar = symbolic::symbol(batch_indvar_str);
     auto& batch_loop = builder.add_map(
         new_sequence,
@@ -266,7 +268,7 @@ passes::LibNodeExpander::ExpandOutcome BatchedGEMMNode::
         auto& dim_end = indvar_ends[i];
 
         std::string indvar_str = builder.find_new_name(indvar_names[i]);
-        builder.add_container(indvar_str, types::Scalar(types::PrimitiveType::UInt64));
+        builder.add_container(indvar_str, types::Scalar(types::get_primitive_type_to_hold_expression(dim_end)));
 
         auto indvar = symbolic::symbol(indvar_str);
         auto init = dim_begin;

--- a/sdfg/src/data_flow/library_nodes/math/blas/batched_gemm_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/blas/batched_gemm_node.cpp
@@ -240,7 +240,7 @@ passes::LibNodeExpander::ExpandOutcome BatchedGEMMNode::
     // Batch loop (outermost)
     std::string batch_indvar_str = builder.find_new_name("_batch");
     builder
-        .add_container(batch_indvar_str, types::Scalar(types::get_primitive_type_to_hold_expression(this->batch_count_)));
+        .add_container(batch_indvar_str, types::Scalar(types::get_primitive_type_to_hold_upper_bound(this->batch_count_)));
     auto batch_indvar = symbolic::symbol(batch_indvar_str);
     auto& batch_loop = builder.add_map(
         new_sequence,
@@ -268,7 +268,7 @@ passes::LibNodeExpander::ExpandOutcome BatchedGEMMNode::
         auto& dim_end = indvar_ends[i];
 
         std::string indvar_str = builder.find_new_name(indvar_names[i]);
-        builder.add_container(indvar_str, types::Scalar(types::get_primitive_type_to_hold_expression(dim_end)));
+        builder.add_container(indvar_str, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim_end)));
 
         auto indvar = symbolic::symbol(indvar_str);
         auto init = dim_begin;

--- a/sdfg/src/data_flow/library_nodes/math/blas/dot_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/blas/dot_node.cpp
@@ -104,7 +104,7 @@ passes::LibNodeExpander::ExpandOutcome DotNode::
     auto& new_sequence = standalone->replace_with_sequence();
 
     std::string loop_var = builder.find_new_name("_i");
-    builder.add_container(loop_var, types::Scalar(types::get_primitive_type_to_hold_expression(this->n_)));
+    builder.add_container(loop_var, types::Scalar(types::get_primitive_type_to_hold_upper_bound(this->n_)));
 
     auto loop_indvar = symbolic::symbol(loop_var);
     auto loop_init = symbolic::integer(0);

--- a/sdfg/src/data_flow/library_nodes/math/blas/dot_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/blas/dot_node.cpp
@@ -6,6 +6,7 @@
 #include "sdfg/builder/structured_sdfg_builder.h"
 
 #include "sdfg/symbolic/symbolic.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg {
 namespace math {
@@ -103,7 +104,7 @@ passes::LibNodeExpander::ExpandOutcome DotNode::
     auto& new_sequence = standalone->replace_with_sequence();
 
     std::string loop_var = builder.find_new_name("_i");
-    builder.add_container(loop_var, types::Scalar(types::PrimitiveType::UInt64));
+    builder.add_container(loop_var, types::Scalar(types::get_primitive_type_to_hold_expression(this->n_)));
 
     auto loop_indvar = symbolic::symbol(loop_var);
     auto loop_init = symbolic::integer(0);

--- a/sdfg/src/data_flow/library_nodes/math/blas/gemm_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/blas/gemm_node.cpp
@@ -171,7 +171,7 @@ passes::LibNodeExpander::ExpandOutcome GEMMNode::
                     ) -> structured_control_flow::StructuredLoop& {
         std::string iv = builder.find_new_name(indvar_names[dim]);
         auto& indvar_end = indvar_ends[dim];
-        auto indvar_type = types::get_primitive_type_to_hold_expression(indvar_end);
+        auto indvar_type = types::get_primitive_type_to_hold_upper_bound(indvar_end);
         builder.add_container(iv, types::Scalar(indvar_type));
         auto sym = symbolic::symbol(iv);
         auto cond = symbolic::Lt(sym, indvar_end);

--- a/sdfg/src/data_flow/library_nodes/math/tensor/arange_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/arange_node.cpp
@@ -4,6 +4,7 @@
 #include "sdfg/data_flow/access_node.h"
 #include "sdfg/data_flow/library_nodes/math/math_node.h"
 #include "sdfg/types/type.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg {
 namespace math {
@@ -127,10 +128,11 @@ passes::LibNodeExpander::ExpandOutcome ArangeNode::
 
     for (size_t i = 0; i < shape_.size(); ++i) {
         std::string var_name = builder.find_new_name("_i" + std::to_string(i));
-        builder.add_container(var_name, types::Scalar(types::PrimitiveType::Int64));
+        auto& dim = shape_[i];
+        builder.add_container(var_name, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
 
         auto sym_var = symbolic::symbol(var_name);
-        auto condition = symbolic::Lt(sym_var, shape_[i]);
+        auto condition = symbolic::Lt(sym_var, dim);
         auto init = symbolic::zero();
         auto update = symbolic::add(sym_var, symbolic::one());
 

--- a/sdfg/src/data_flow/library_nodes/math/tensor/broadcast_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/broadcast_node.cpp
@@ -1,6 +1,7 @@
 #include "sdfg/data_flow/library_nodes/math/tensor/broadcast_node.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
 #include "sdfg/structured_control_flow/for.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg {
 namespace math {
@@ -129,10 +130,11 @@ passes::LibNodeExpander::ExpandOutcome BroadcastNode::
 
     for (size_t i = 0; i < output_shape_.size(); ++i) {
         std::string var_name = builder.find_new_name("_i" + std::to_string(i));
-        builder.add_container(var_name, types::Scalar(types::PrimitiveType::Int64));
+        auto& dim = output_shape_[i];
+        builder.add_container(var_name, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
 
         auto sym_var = symbolic::symbol(var_name);
-        auto condition = symbolic::Lt(sym_var, output_shape_[i]);
+        auto condition = symbolic::Lt(sym_var, dim);
         auto init = symbolic::zero();
         auto update = symbolic::add(sym_var, symbolic::one());
 

--- a/sdfg/src/data_flow/library_nodes/math/tensor/concat_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/concat_node.cpp
@@ -29,6 +29,7 @@
 #include "sdfg/types/scalar.h"
 #include "sdfg/types/tensor.h"
 #include "sdfg/types/type.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg {
 namespace math {
@@ -171,13 +172,12 @@ passes::LibNodeExpander::ExpandOutcome ConcatNode::
 
     auto& dfg = this->get_parent();
 
-    types::Scalar indvar_type(types::PrimitiveType::UInt64);
     structured_control_flow::Sequence* current_seq = &new_sequence;
     data_flow::Subset subset;
     subset.reserve(this->result_layout_.dims());
     for (auto dim : this->result_layout_.shape()) {
         auto indvar_container = builder.find_new_name("_i");
-        builder.add_container(indvar_container, indvar_type);
+        builder.add_container(indvar_container, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
         auto indvar = symbolic::symbol(indvar_container);
         subset.push_back(indvar);
         auto& map = builder.add_map(

--- a/sdfg/src/data_flow/library_nodes/math/tensor/conditional_copy_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/conditional_copy_node.cpp
@@ -27,6 +27,7 @@
 #include "sdfg/types/scalar.h"
 #include "sdfg/types/tensor.h"
 #include "sdfg/types/type.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg {
 namespace math {
@@ -232,13 +233,12 @@ passes::LibNodeExpander::ExpandOutcome ConditionalTensorCopyNode::
     auto& new_sequence = standalone->replace_with_sequence();
 
     // Add map nest over shape
-    types::Scalar indvar_type(types::PrimitiveType::UInt64);
     structured_control_flow::Sequence* current_seq = &new_sequence;
     data_flow::Subset subset;
     subset.reserve(this->layout_y_.dims());
     for (auto dim : this->layout_y_.shape()) {
         auto indvar_container = builder.find_new_name("_i");
-        builder.add_container(indvar_container, indvar_type);
+        builder.add_container(indvar_container, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
         auto indvar = symbolic::symbol(indvar_container);
         subset.push_back(indvar);
         auto& map = builder.add_map(

--- a/sdfg/src/data_flow/library_nodes/math/tensor/copy_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/copy_node.cpp
@@ -30,6 +30,7 @@
 #include "sdfg/symbolic/symbolic.h"
 #include "sdfg/types/scalar.h"
 #include "sdfg/types/type.h"
+#include "sdfg/types/utils.h"
 #include "symengine/symengine_rcp.h"
 
 namespace sdfg {
@@ -44,19 +45,19 @@ void TensorCopyNode::expand_identity_mode(
     auto& dfg = this->get_parent();
     structured_control_flow::Sequence* current_seq = &sequence;
     int dims = this->layout_x_.dims();
-    types::Scalar indvar_type(types::PrimitiveType::UInt64);
 
     data_flow::Subset indvars;
     indvars.reserve(dims);
     for (int i = 0; i < dims; i++) {
         auto indvar_container = builder.find_new_name("_i");
-        builder.add_container(indvar_container, indvar_type);
+        auto& dim = this->layout_x_.get_dim(i);
+        builder.add_container(indvar_container, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
         auto indvar = symbolic::symbol(indvar_container);
         indvars.push_back(indvar);
         auto& map = builder.add_map(
             *current_seq,
             indvar,
-            symbolic::Lt(indvar, this->layout_x_.get_dim(i)),
+            symbolic::Lt(indvar, dim),
             symbolic::zero(),
             symbolic::add(indvar, symbolic::one()),
             structured_control_flow::ScheduleType_Sequential::create(),
@@ -115,19 +116,19 @@ void TensorCopyNode::expand_permutation_mode(
 
     auto& dfg = this->get_parent();
     structured_control_flow::Sequence* current_seq = &sequence;
-    types::Scalar indvar_type(types::PrimitiveType::UInt64);
 
     data_flow::Subset indvars_y;
     indvars_y.reserve(dims);
     for (int i = 0; i < dims; i++) {
         auto indvar_container = builder.find_new_name("_i");
-        builder.add_container(indvar_container, indvar_type);
+        auto& dim = this->layout_y_.get_dim(i);
+        builder.add_container(indvar_container, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
         auto indvar = symbolic::symbol(indvar_container);
         indvars_y.push_back(indvar);
         auto& map = builder.add_map(
             *current_seq,
             indvar,
-            symbolic::Lt(indvar, this->layout_y_.get_dim(i)),
+            symbolic::Lt(indvar, dim),
             symbolic::zero(),
             symbolic::add(indvar, symbolic::one()),
             structured_control_flow::ScheduleType_Sequential::create(),
@@ -175,19 +176,19 @@ void TensorCopyNode::expand_squeeze_mode(
     auto& dfg = this->get_parent();
     structured_control_flow::Sequence* current_seq = &sequence;
     int smaller_dims = smaller.dims();
-    types::Scalar indvar_type(types::PrimitiveType::UInt64);
 
     data_flow::Subset indvars_smaller;
     indvars_smaller.reserve(smaller_dims);
     for (int i = 0; i < smaller_dims; i++) {
         auto indvar_container = builder.find_new_name("_i");
-        builder.add_container(indvar_container, indvar_type);
+        auto& dim = smaller.get_dim(i);
+        builder.add_container(indvar_container, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
         auto indvar = symbolic::symbol(indvar_container);
         indvars_smaller.push_back(indvar);
         auto& map = builder.add_map(
             *current_seq,
             indvar,
-            symbolic::Lt(indvar, smaller.get_dim(i)),
+            symbolic::Lt(indvar, dim),
             symbolic::zero(),
             symbolic::add(indvar, symbolic::one()),
             structured_control_flow::ScheduleType_Sequential::create(),
@@ -264,9 +265,9 @@ void TensorCopyNode::expand_reshape_mode(
     }
 
     auto& dfg = this->get_parent();
-    types::Scalar indvar_type(types::PrimitiveType::UInt64);
     auto indvar_container = builder.find_new_name("_i");
-    builder.add_container(indvar_container, indvar_type);
+    builder
+        .add_container(indvar_container, types::Scalar(types::get_primitive_type_to_hold_upper_bound(total_elements)));
     auto indvar = symbolic::symbol(indvar_container);
     auto& map = builder.add_map(
         sequence,

--- a/sdfg/src/data_flow/library_nodes/math/tensor/einsum_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/einsum_node.cpp
@@ -31,6 +31,7 @@
 #include "sdfg/symbolic/symbolic.h"
 #include "sdfg/types/scalar.h"
 #include "sdfg/types/type.h"
+#include "sdfg/types/utils.h"
 #include "symengine/symbol.h"
 
 namespace sdfg {
@@ -256,7 +257,9 @@ bool EinsumNode::expand(builder::StructuredSDFGBuilder& builder, analysis::Analy
         if (builder.subject().exists(indvar_name)) {
             continue;
         }
-        builder.add_container(indvar_name, types::Scalar(types::PrimitiveType::Int64));
+        auto bound_type = types::get_primitive_type_to_hold_upper_bound(this->bound(i));
+        auto init_type = types::get_primitive_type_to_hold_lower_bound(this->init(i));
+        builder.add_container(indvar_name, types::Scalar(types::get_primitive_type_to_hold(bound_type, init_type)));
     }
 
     // Add loops

--- a/sdfg/src/data_flow/library_nodes/math/tensor/elementwise_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/elementwise_node.cpp
@@ -177,7 +177,7 @@ std::pair<structured_control_flow::Sequence*, std::vector<symbolic::Expression>>
     for (size_t i = 0; i < shape.size(); i++) {
         std::string indvar_str = builder.find_new_name("_i");
         auto& dim_end = shape.at(i);
-        builder.add_container(indvar_str, types::Scalar(types::get_primitive_type_to_hold_expression(dim_end)));
+        builder.add_container(indvar_str, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim_end)));
 
         auto indvar = symbolic::symbol(indvar_str);
         auto init = symbolic::zero();

--- a/sdfg/src/data_flow/library_nodes/math/tensor/elementwise_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/elementwise_node.cpp
@@ -4,6 +4,7 @@
 #include "sdfg/builder/structured_sdfg_builder.h"
 #include "sdfg/data_flow/tasklet.h"
 #include "sdfg/types/type.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg {
 namespace math {
@@ -175,12 +176,13 @@ std::pair<structured_control_flow::Sequence*, std::vector<symbolic::Expression>>
 
     for (size_t i = 0; i < shape.size(); i++) {
         std::string indvar_str = builder.find_new_name("_i");
-        builder.add_container(indvar_str, types::Scalar(types::PrimitiveType::UInt64));
+        auto& dim_end = shape.at(i);
+        builder.add_container(indvar_str, types::Scalar(types::get_primitive_type_to_hold_expression(dim_end)));
 
         auto indvar = symbolic::symbol(indvar_str);
         auto init = symbolic::zero();
         auto update = symbolic::add(indvar, symbolic::one());
-        auto condition = symbolic::Lt(indvar, shape.at(i));
+        auto condition = symbolic::Lt(indvar, dim_end);
         last_map = &builder.add_map(
             *last_scope,
             indvar,

--- a/sdfg/src/data_flow/library_nodes/math/tensor/embedding_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/embedding_node.cpp
@@ -1,6 +1,7 @@
 #include "sdfg/data_flow/library_nodes/math/tensor/embedding_node.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
 #include "sdfg/structured_control_flow/for.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg {
 namespace math {
@@ -110,10 +111,11 @@ passes::LibNodeExpander::ExpandOutcome EmbeddingNode::
 
     for (size_t i = 0; i < output_shape.size(); ++i) {
         std::string var_name = builder.find_new_name("_i" + std::to_string(i));
-        builder.add_container(var_name, types::Scalar(types::PrimitiveType::Int64));
+        auto& dim = output_shape[i];
+        builder.add_container(var_name, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
 
         auto sym_var = symbolic::symbol(var_name);
-        auto condition = symbolic::Lt(sym_var, output_shape[i]);
+        auto condition = symbolic::Lt(sym_var, dim);
         auto init = symbolic::zero();
         auto update = symbolic::add(sym_var, symbolic::one());
 

--- a/sdfg/src/data_flow/library_nodes/math/tensor/embedding_renorm_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/embedding_renorm_node.cpp
@@ -14,6 +14,7 @@
 #include "sdfg/structured_control_flow/map.h"
 #include "sdfg/types/scalar.h"
 #include "sdfg/types/type.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg {
 namespace math {
@@ -259,9 +260,10 @@ passes::LibNodeExpander::ExpandOutcome EmbeddingRenormNode::
     structured_control_flow::Sequence* inner_scope = &new_sequence;
     for (size_t i = 0; i < nB; ++i) {
         std::string var_name = builder.find_new_name("_i" + std::to_string(i));
-        builder.add_container(var_name, types::Scalar(types::PrimitiveType::Int64));
+        auto& dim = this->indices_layout_.get_dim(i);
+        builder.add_container(var_name, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
         auto sym_var = symbolic::symbol(var_name);
-        auto condition = symbolic::Lt(sym_var, this->indices_layout_.get_dim(i));
+        auto condition = symbolic::Lt(sym_var, dim);
         auto init = symbolic::zero();
         auto update = symbolic::add(sym_var, symbolic::one());
         auto& loop = builder.add_map(
@@ -317,7 +319,7 @@ passes::LibNodeExpander::ExpandOutcome EmbeddingRenormNode::
     // Sequential accumulation loop over the embedding dimension.
     {
         std::string j_name = builder.find_new_name("_j");
-        builder.add_container(j_name, types::Scalar(types::PrimitiveType::Int64));
+        builder.add_container(j_name, types::Scalar(types::get_primitive_type_to_hold_upper_bound(embedding_dim)));
         auto j_sym = symbolic::symbol(j_name);
         auto& acc_loop = builder.add_for(
             *inner_scope,
@@ -461,7 +463,7 @@ passes::LibNodeExpander::ExpandOutcome EmbeddingRenormNode::
     // In-place scaling loop: W[idx, j] *= scale.
     {
         std::string j_name = builder.find_new_name("_j_scale");
-        builder.add_container(j_name, types::Scalar(types::PrimitiveType::Int64));
+        builder.add_container(j_name, types::Scalar(types::get_primitive_type_to_hold_upper_bound(embedding_dim)));
         auto j_sym = symbolic::symbol(j_name);
         auto& scale_loop = builder.add_map(
             *inner_scope,

--- a/sdfg/src/data_flow/library_nodes/math/tensor/index_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/index_node.cpp
@@ -29,6 +29,7 @@
 #include "sdfg/types/scalar.h"
 #include "sdfg/types/tensor.h"
 #include "sdfg/types/type.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg {
 namespace math {
@@ -317,7 +318,6 @@ passes::LibNodeExpander::ExpandOutcome IndexNode::
     }
     auto prim_type = y_edge->base_type().primitive_type();
     types::Scalar base_type(prim_type);
-    types::Scalar indvar_type(types::PrimitiveType::Int64);
     bool contiguous_indices = this->contiguous_indices();
     symbolic::MultiExpression broadcast_shape = this->common_indices_shape();
     long long broadcast_dims = broadcast_shape.size();
@@ -328,7 +328,8 @@ passes::LibNodeExpander::ExpandOutcome IndexNode::
     int y_dims = this->y_layout_.dims();
     for (long long i = 0; i < y_dims; i++) {
         auto indvar_container = builder.find_new_name("_i");
-        builder.add_container(indvar_container, indvar_type);
+        auto& dim = y_layout_.get_dim(i);
+        builder.add_container(indvar_container, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
         auto indvar = symbolic::symbol(indvar_container);
         y_subset.push_back(indvar);
 

--- a/sdfg/src/data_flow/library_nodes/math/tensor/layernorm_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/layernorm_node.cpp
@@ -29,6 +29,7 @@
 #include "sdfg/structured_control_flow/sequence.h"
 #include "sdfg/symbolic/symbolic.h"
 #include "sdfg/types/tensor.h"
+#include "sdfg/types/utils.h"
 #include "symengine/add.h"
 #include "symengine/mul.h"
 
@@ -404,14 +405,12 @@ passes::LibNodeExpander::ExpandOutcome LayerNormNode::
     }
     auto prim_type = this->primitive_type(graph);
     types::Scalar base_type(prim_type);
-    types::Scalar indvar_type(types::PrimitiveType::UInt64);
 
     // _ln_norm_dim_sum_int = Mul_{d in normalized_shape} d
     auto norm_dim_sum_int_container = builder.find_new_name("_ln_norm_dim_sum_int");
-    builder.add_container(norm_dim_sum_int_container, indvar_type);
-    builder.add_assignments(
-        new_sequence, {{symbolic::symbol(norm_dim_sum_int_container), SymEngine::mul(this->normalized_shape_)}}
-    );
+    auto dim = SymEngine::mul(this->normalized_shape_);
+    builder.add_container(norm_dim_sum_int_container, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
+    builder.add_assignments(new_sequence, {{symbolic::symbol(norm_dim_sum_int_container), dim}});
 
     auto norm_dim_sum_container = builder.find_new_name("_ln_norm_dim_sum");
     builder.add_container(norm_dim_sum_container, base_type);
@@ -432,7 +431,7 @@ passes::LibNodeExpander::ExpandOutcome LayerNormNode::
     outer_subset.reserve(non_normalized_shape.size());
     for (auto dim : non_normalized_shape) {
         auto indvar_container = builder.find_new_name("_i");
-        builder.add_container(indvar_container, indvar_type);
+        builder.add_container(indvar_container, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
         auto indvar = symbolic::symbol(indvar_container);
         outer_subset.push_back(indvar);
         auto& map = builder.add_map(
@@ -471,7 +470,7 @@ passes::LibNodeExpander::ExpandOutcome LayerNormNode::
         // Add reduction nest over normalized shape
         for (auto dim : this->normalized_shape_) {
             auto indvar_container = builder.find_new_name("_i");
-            builder.add_container(indvar_container, indvar_type);
+            builder.add_container(indvar_container, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
             auto indvar = symbolic::symbol(indvar_container);
             mean_subset.push_back(indvar);
             auto& reduce = builder.add_reduce(
@@ -534,7 +533,7 @@ passes::LibNodeExpander::ExpandOutcome LayerNormNode::
         // Add reduction nest over normalized shape
         for (auto dim : this->normalized_shape_) {
             auto indvar_container = builder.find_new_name("_i");
-            builder.add_container(indvar_container, indvar_type);
+            builder.add_container(indvar_container, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
             auto indvar = symbolic::symbol(indvar_container);
             std_subset.push_back(indvar);
             auto& reduce = builder.add_reduce(
@@ -637,7 +636,7 @@ passes::LibNodeExpander::ExpandOutcome LayerNormNode::
         // Add map nest over normalized shape
         for (auto dim : this->normalized_shape_) {
             auto indvar_container = builder.find_new_name("_i");
-            builder.add_container(indvar_container, indvar_type);
+            builder.add_container(indvar_container, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
             auto indvar = symbolic::symbol(indvar_container);
             y_subset.push_back(indvar);
             inner_subset.push_back(indvar);

--- a/sdfg/src/data_flow/library_nodes/math/tensor/pooling_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/pooling_node.cpp
@@ -7,6 +7,7 @@
 #include "sdfg/data_flow/library_nodes/math/tensor/tensor_node.h"
 #include "sdfg/symbolic/symbolic.h"
 #include "sdfg/types/type.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg {
 namespace math {
@@ -158,7 +159,7 @@ passes::LibNodeExpander::ExpandOutcome PoolingNode::
 
     // Map over batch
     std::string n_str = builder.find_new_name("n");
-    builder.add_container(n_str, types::Scalar(types::PrimitiveType::UInt64));
+    builder.add_container(n_str, types::Scalar(types::get_primitive_type_to_hold_upper_bound(N)));
     auto n_var = symbolic::symbol(n_str);
     auto& map_n = builder.add_map(
         *current_scope,
@@ -174,7 +175,7 @@ passes::LibNodeExpander::ExpandOutcome PoolingNode::
 
     // Map over channel
     std::string c_str = builder.find_new_name("c");
-    builder.add_container(c_str, types::Scalar(types::PrimitiveType::UInt64));
+    builder.add_container(c_str, types::Scalar(types::get_primitive_type_to_hold_upper_bound(C)));
     auto c_var = symbolic::symbol(c_str);
     auto& map_c = builder.add_map(
         *current_scope,
@@ -191,12 +192,13 @@ passes::LibNodeExpander::ExpandOutcome PoolingNode::
     // Map over each output spatial dimension
     for (size_t i = 0; i < spatial_dims; ++i) {
         std::string od_str = builder.find_new_name("od" + std::to_string(i));
-        builder.add_container(od_str, types::Scalar(types::PrimitiveType::UInt64));
+        auto& dim = output_spatial_dims[i];
+        builder.add_container(od_str, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
         auto od_var = symbolic::symbol(od_str);
         auto& map_od = builder.add_map(
             *current_scope,
             od_var,
-            symbolic::Lt(od_var, output_spatial_dims[i]),
+            symbolic::Lt(od_var, dim),
             symbolic::zero(),
             symbolic::add(od_var, symbolic::one()),
             structured_control_flow::ScheduleType_Sequential::create(),
@@ -256,12 +258,13 @@ passes::LibNodeExpander::ExpandOutcome PoolingNode::
                                    : structured_control_flow::ReductionOperation::Add);
     for (size_t i = 0; i < spatial_dims; ++i) {
         std::string k_str = builder.find_new_name("k" + std::to_string(i));
-        builder.add_container(k_str, types::Scalar(types::PrimitiveType::UInt64));
+        auto& dim = kernel_shape_[i];
+        builder.add_container(k_str, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
         auto k_var = symbolic::symbol(k_str);
         auto& reduce_k = builder.add_reduce(
             *loop_scope,
             k_var,
-            symbolic::Lt(k_var, kernel_shape_[i]),
+            symbolic::Lt(k_var, dim),
             symbolic::zero(),
             symbolic::add(k_var, symbolic::one()),
             {{.operation = reduce_op, .container = accum_var}},

--- a/sdfg/src/data_flow/library_nodes/math/tensor/reduce_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/reduce_node.cpp
@@ -5,6 +5,8 @@
 
 #include <algorithm>
 
+#include "sdfg/types/utils.h"
+
 namespace sdfg {
 namespace math {
 namespace tensor {
@@ -219,12 +221,13 @@ passes::LibNodeExpander::ExpandOutcome ReduceNode::expand_inner(
         // Generate outer parallel loops (Maps)
         for (size_t dim_idx : outer_dims) {
             std::string indvar_str = builder.find_new_name("_i");
-            builder.add_container(indvar_str, types::Scalar(types::PrimitiveType::Int64));
+            auto& limit = shape_[dim_idx];
+            builder.add_container(indvar_str, types::Scalar(types::get_primitive_type_to_hold_upper_bound(limit)));
 
             auto indvar = symbolic::symbol(indvar_str);
             auto init = symbolic::zero();
             auto update = symbolic::add(indvar, symbolic::one());
-            auto condition = symbolic::Lt(indvar, shape_[dim_idx]);
+            auto condition = symbolic::Lt(indvar, limit);
 
             auto& map = builder.add_map(
                 *last_scope,
@@ -243,12 +246,13 @@ passes::LibNodeExpander::ExpandOutcome ReduceNode::expand_inner(
         auto reduction_operation = this->reduction_operation();
         for (size_t dim_idx : inner_dims) {
             std::string indvar_str = builder.find_new_name("_k");
-            builder.add_container(indvar_str, types::Scalar(types::PrimitiveType::Int64));
+            auto& limit = shape_[dim_idx];
+            builder.add_container(indvar_str, types::Scalar(types::get_primitive_type_to_hold_upper_bound(limit)));
 
             auto indvar = symbolic::symbol(indvar_str);
             auto init = symbolic::zero();
             auto update = symbolic::add(indvar, symbolic::one());
-            auto condition = symbolic::Lt(indvar, shape_[dim_idx]);
+            auto condition = symbolic::Lt(indvar, limit);
 
             if (reduction_operation.has_value()) {
                 last_loop = &builder.add_reduce(

--- a/sdfg/src/data_flow/library_nodes/math/tensor/reduce_ops/mean_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/reduce_ops/mean_node.cpp
@@ -3,6 +3,7 @@
 #include "sdfg/builder/structured_sdfg_builder.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/elementwise_ops/div_node.h"
 #include "sdfg/data_flow/library_nodes/math/tensor/reduce_ops/sum_node.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg {
 namespace math {
@@ -46,9 +47,6 @@ passes::LibNodeExpander::ExpandOutcome MeanNode::expand_inner(
     builder.add_computational_memlet(sum_block, sum_out_node, sum_node, "Y", {}, out_type, this->debug_info());
 
     // Create Count (symbolically)
-    auto count_container = builder.find_new_name("_mean_count");
-    builder.add_container(count_container, types::Scalar(types::PrimitiveType::Int64));
-
     symbolic::Expression count_expr = symbolic::one();
     for (auto axis : axes_) {
         int64_t ax = axis;
@@ -56,6 +54,10 @@ passes::LibNodeExpander::ExpandOutcome MeanNode::expand_inner(
         symbolic::Expression dim = shape_[ax];
         count_expr = symbolic::mul(count_expr, dim);
     }
+
+    auto count_container = builder.find_new_name("_mean_count");
+    builder.add_container(count_container, types::Scalar(types::get_primitive_type_to_hold_upper_bound(count_expr)));
+
     builder.add_assignments(seq, {{symbolic::symbol(count_container), count_expr}}, this->debug_info());
 
     // Create DivNode

--- a/sdfg/src/data_flow/library_nodes/math/tensor/tensor_expansion_utils.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/tensor_expansion_utils.cpp
@@ -4,6 +4,7 @@
 #include "sdfg/exceptions.h"
 #include "sdfg/structured_control_flow/map.h"
 #include "sdfg/types/scalar.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg::math::tensor {
 
@@ -43,20 +44,20 @@ std::vector<MapDimension> create_maps(
     std::vector<MapDimension> result;
     result.reserve(shape.size());
 
-    types::Scalar indvar_type(types::PrimitiveType::Int64);
     structured_control_flow::Sequence* current_seq = &parent_seq;
 
     for (size_t i = 0; i < shape.size(); ++i) {
         // Create induction variable for this dimension
         std::string loop_var_name = builder.find_new_name("i" + std::to_string(i));
-        builder.add_container(loop_var_name, indvar_type);
+        auto& dim = shape[i];
+        builder.add_container(loop_var_name, types::Scalar(types::get_primitive_type_to_hold_upper_bound(dim)));
         auto loop_var = symbolic::symbol(loop_var_name);
 
         // Create the map: for (i = 0; i < dim_size; i++)
         auto& map = builder.add_map(
             *current_seq,
             loop_var,
-            symbolic::Lt(loop_var, shape[i]),
+            symbolic::Lt(loop_var, dim),
             symbolic::integer(0),
             symbolic::add(loop_var, symbolic::one()),
             structured_control_flow::ScheduleType_Sequential::create()

--- a/sdfg/src/data_flow/library_nodes/math/tensor/tensor_layout.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/tensor_layout.cpp
@@ -314,77 +314,7 @@ std::unique_ptr<TensorLayout> TensorLayout::reshape(const symbolic::MultiExpress
 
 types::PrimitiveType TensorLayout::get_tensor_indvar_type_for_shape(const std::vector<symbolic::Expression>& shape) {
     auto num_elems = SymEngine::mul(shape);
-    return types::get_primitive_type_to_hold_expression(num_elems);
-}
-
-types::PrimitiveType TensorLayout::get_combined_tensor_indvar_type(types::PrimitiveType a, types::PrimitiveType b) {
-    // Describe each supported integer type by its bit width and signedness.
-    auto bit_width = [](types::PrimitiveType t) -> int {
-        switch (t) {
-            case types::PrimitiveType::Int32:
-            case types::PrimitiveType::UInt32:
-                return 32;
-            case types::PrimitiveType::Int64:
-            case types::PrimitiveType::UInt64:
-                return 64;
-            default:
-                throw std::invalid_argument(
-                    "Unsupported type for tensor indvar: " + std::string(types::primitive_type_to_string(t))
-                );
-        }
-    };
-    auto is_signed = [](types::PrimitiveType t) -> bool {
-        switch (t) {
-            case types::PrimitiveType::Int32:
-            case types::PrimitiveType::Int64:
-                return true;
-            case types::PrimitiveType::UInt32:
-            case types::PrimitiveType::UInt64:
-                return false;
-            default:
-                throw std::invalid_argument(
-                    "Unsupported type for tensor indvar: " + std::string(types::primitive_type_to_string(t))
-                );
-        }
-    };
-
-    // Can every value of `src` be extended into `dst` without any loss?
-    auto fits_in = [&](types::PrimitiveType src, types::PrimitiveType dst) -> bool {
-        const int src_bits = bit_width(src);
-        const int dst_bits = bit_width(dst);
-        const bool src_signed = is_signed(src);
-        const bool dst_signed = is_signed(dst);
-
-        if (src_signed == dst_signed) {
-            // Same signedness: the destination just needs to be at least as wide.
-            return dst_bits >= src_bits;
-        }
-        if (!src_signed && dst_signed) {
-            // Unsigned into signed: need one extra bit to hold the unsigned range.
-            return dst_bits > src_bits;
-        }
-        // Signed into unsigned: negative values can never be represented.
-        return false;
-    };
-
-    // Candidates ordered from smallest to largest capacity so the first match is
-    // the tightest common type that both operands extend into without loss.
-    static constexpr types::PrimitiveType candidates[] = {
-        types::PrimitiveType::Int32,
-        types::PrimitiveType::UInt32,
-        types::PrimitiveType::Int64,
-        types::PrimitiveType::UInt64,
-    };
-    for (auto candidate : candidates) {
-        if (fits_in(a, candidate) && fits_in(b, candidate)) {
-            return candidate;
-        }
-    }
-
-    throw std::invalid_argument(
-        "Cannot combine types " + std::string(types::primitive_type_to_string(a)) + " and " +
-        types::primitive_type_to_string(b)
-    );
+    return types::get_primitive_type_to_hold_upper_bound(num_elems);
 }
 
 } // namespace sdfg::math::tensor

--- a/sdfg/src/data_flow/library_nodes/math/tensor/upsample_node.cpp
+++ b/sdfg/src/data_flow/library_nodes/math/tensor/upsample_node.cpp
@@ -6,6 +6,7 @@
 #include "sdfg/builder/structured_sdfg_builder.h"
 #include "sdfg/symbolic/symbolic.h"
 #include "sdfg/types/type.h"
+#include "sdfg/types/utils.h"
 
 namespace sdfg {
 namespace math {
@@ -88,7 +89,6 @@ passes::LibNodeExpander::ExpandOutcome UpsampleBilinear2DNode::
 
     types::Scalar double_type(types::PrimitiveType::Double);
     types::Scalar int_type(types::PrimitiveType::Int64);
-    types::Scalar loop_type(types::PrimitiveType::UInt64);
 
     symbolic::Expression N = output_shape_[0];
     symbolic::Expression C = output_shape_[1];
@@ -285,7 +285,7 @@ passes::LibNodeExpander::ExpandOutcome UpsampleBilinear2DNode::
 
     // Map over batch dimension N.
     std::string n_str = builder.find_new_name("n");
-    builder.add_container(n_str, loop_type);
+    builder.add_container(n_str, types::Scalar(types::get_primitive_type_to_hold_upper_bound(N)));
     auto n_var = symbolic::symbol(n_str);
     auto& map_n = builder.add_map(
         *scope,
@@ -300,7 +300,7 @@ passes::LibNodeExpander::ExpandOutcome UpsampleBilinear2DNode::
 
     // Map over channel dimension C.
     std::string c_str = builder.find_new_name("c");
-    builder.add_container(c_str, loop_type);
+    builder.add_container(c_str, types::Scalar(types::get_primitive_type_to_hold_upper_bound(C)));
     auto c_var = symbolic::symbol(c_str);
     auto& map_c = builder.add_map(
         *scope,
@@ -315,7 +315,7 @@ passes::LibNodeExpander::ExpandOutcome UpsampleBilinear2DNode::
 
     // Map over output height.
     std::string oh_str = builder.find_new_name("oh");
-    builder.add_container(oh_str, loop_type);
+    builder.add_container(oh_str, types::Scalar(types::get_primitive_type_to_hold_upper_bound(Hout)));
     auto oh_var = symbolic::symbol(oh_str);
     auto& map_oh = builder.add_map(
         *scope,
@@ -333,7 +333,7 @@ passes::LibNodeExpander::ExpandOutcome UpsampleBilinear2DNode::
 
     // Map over output width.
     std::string ow_str = builder.find_new_name("ow");
-    builder.add_container(ow_str, loop_type);
+    builder.add_container(ow_str, types::Scalar(types::get_primitive_type_to_hold_upper_bound(Wout)));
     auto ow_var = symbolic::symbol(ow_str);
     auto& map_ow = builder.add_map(
         oh_scope,

--- a/sdfg/src/structured_control_flow/structured_loop.cpp
+++ b/sdfg/src/structured_control_flow/structured_loop.cpp
@@ -1,5 +1,6 @@
 #include "sdfg/structured_control_flow/structured_loop.h"
 
+#include "sdfg/function.h"
 #include "sdfg/symbolic/conjunctive_normal_form.h"
 #include "sdfg/symbolic/polynomials.h"
 #include "symengine/subs.h"
@@ -23,9 +24,26 @@ StructuredLoop::StructuredLoop(
 }
 
 void StructuredLoop::validate(const Function& function) const {
-    if (this->indvar_.is_null()) {
-        throw InvalidSDFGException("StructuredLoop: Induction variable cannot be null");
+    auto indvar = this->indvar_;
+    if (indvar.is_null()) {
+        throw InvalidSDFGException(
+            "StructuredLoop: Induction variable cannot be null on #" + std::to_string(this->element_id())
+        );
     }
+    if (!function.exists(indvar->get_name())) {
+        throw InvalidSDFGException(
+            "StructuredLoop: Indvar '" + indvar->get_name() + "' must exist as container on #" +
+            std::to_string(this->element_id())
+        );
+    }
+    auto& indvar_type = function.type(indvar->get_name());
+    if (indvar_type.type_id() == types::TypeID::Scalar && types::is_unsigned(indvar_type.primitive_type())) {
+        throw InvalidSDFGException(
+            "StructuredLoop: Expressions must be signed: '" + indvar->get_name() + "' is unsigned on #" +
+            std::to_string(this->element_id())
+        );
+    }
+
     if (this->init_.is_null()) {
         throw InvalidSDFGException("StructuredLoop: Initialization expression cannot be null");
     }

--- a/sdfg/src/structured_control_flow/structured_loop.cpp
+++ b/sdfg/src/structured_control_flow/structured_loop.cpp
@@ -37,10 +37,18 @@ void StructuredLoop::validate(const Function& function) const {
         );
     }
     auto& indvar_type = function.type(indvar->get_name());
-    if (indvar_type.type_id() == types::TypeID::Scalar && types::is_unsigned(indvar_type.primitive_type())) {
+    if (indvar_type.type_id() == types::TypeID::Scalar) {
+        if (types::is_unsigned(indvar_type.primitive_type())) {
+            throw InvalidSDFGException(
+                "StructuredLoop: Expressions must be signed: '" + indvar->get_name() + "' is " +
+                types::primitive_type_to_string(indvar_type.primitive_type()) + " on #" +
+                std::to_string(this->element_id())
+            );
+        }
+    } else if (indvar_type.type_id() != types::TypeID::Pointer) {
         throw InvalidSDFGException(
-            "StructuredLoop: Expressions must be signed: '" + indvar->get_name() + "' is unsigned on #" +
-            std::to_string(this->element_id())
+            "StructuredLoop: Expressions must be signed Scalars or Ptr: '" + indvar->get_name() + "' is " +
+            indvar_type.print() + " on #" + std::to_string(this->element_id())
         );
     }
 

--- a/sdfg/src/symbolic/extreme_values.cpp
+++ b/sdfg/src/symbolic/extreme_values.cpp
@@ -1,5 +1,6 @@
 #include "sdfg/symbolic/extreme_values.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <limits>
 #include <vector>
@@ -1331,18 +1332,33 @@ bool descend_min_and(
 // appearing in both `s`'s bound and a constraint) now cancels syntactically,
 // which interval bounding cannot do when the base is a non-polynomial function of
 // another generator (Stream-K's `64*imod(idiv(t,16),16)`).
+//
+// `only_reducing` restricts to substitutions that strictly shrink the atom set
+// (i.e. actually cancel a coupled symbol). Those are cheap and often decisive,
+// so `prove_ge_zero` runs a reducing-only pass *before* the interval descent to
+// keep the shared work budget from being drained on the coupled goal before the
+// cancellation shortcut is ever reached.
 bool descend_symbol_bounds(
     const Expression& diff,
     const SymbolSet& parameters,
     const Assumptions& assumptions,
     bool tight,
     bool strict,
-    int depth
+    int depth,
+    bool only_reducing
 ) {
     auto e = symbolic::expand(diff);
     auto zero = symbolic::zero();
     auto one = symbolic::integer(1);
     auto two = symbolic::integer(2);
+    const size_t base_atoms = symbolic::atoms(e).size();
+
+    // Collect every valid single-symbol bound substitution, then try the ones
+    // that cancel the most terms first (fewest atoms remaining). Substituting a
+    // symbol by its symbolic bound can cancel a coupled term -- e.g. `i + j20`
+    // with `j20 >= 64 - i + i_tile0` collapses to `64 + i_tile0`, dropping `i`
+    // -- turning an unprovable coupled goal into a trivially-bounded one.
+    std::vector<Expression> candidates;
     for (auto& s : symbolic::atoms(e)) {
         if (parameters.find(s) != parameters.end()) continue;
         auto it = assumptions.find(s);
@@ -1367,6 +1383,15 @@ bool descend_symbol_bounds(
         if (symbolic::atoms(bound).count(s)) continue;
 
         Expression replaced = symbolic::simplify(symbolic::expand(symbolic::subs(e, s, bound)));
+        if (only_reducing && symbolic::atoms(replaced).size() >= base_atoms) continue;
+        candidates.push_back(replaced);
+    }
+
+    std::stable_sort(candidates.begin(), candidates.end(), [](const Expression& a, const Expression& b) {
+        return symbolic::atoms(a).size() < symbolic::atoms(b).size();
+    });
+
+    for (auto& replaced : candidates) {
         if (prove_ge_zero(replaced, parameters, assumptions, tight, strict, depth - 1)) return true;
     }
     return false;
@@ -1395,6 +1420,15 @@ bool prove_ge_zero(
     } else {
         if (symbolic::is_true(symbolic::Ge(e, symbolic::zero()))) return true;
     }
+
+    // Cheap coupling shortcut before the interval descent: a symbolic-bound
+    // substitution that strictly cancels a coupled symbol (e.g. `i + j20` with
+    // `j20 >= 64 - i + i_tile0` collapsing to `64 + i_tile0`) is both decisive
+    // and inexpensive. Running it here keeps the shared work budget from being
+    // exhausted by `try_lb`'s min/max fan-out on the coupled goal before the
+    // cancellation is ever tried.
+    if (depth > 0 && descend_symbol_bounds(e, parameters, assumptions, tight, strict, depth, /*only_reducing=*/true))
+        return true;
 
     // Interval check via BoundAnalysis with the supplied parameter set.
     auto try_lb = [&](const SymbolSet& params) -> bool {
@@ -1445,7 +1479,7 @@ bool prove_ge_zero(
     // Symbolic-bound substitution: recover coupling lost by per-symbol interval
     // bounding (e.g. `_j1 - base` when `_j1 in [base, base+K]` and `base` is a
     // non-polynomial function of another generator).
-    if (descend_symbol_bounds(e, parameters, assumptions, tight, strict, depth)) return true;
+    if (descend_symbol_bounds(e, parameters, assumptions, tight, strict, depth, /*only_reducing=*/false)) return true;
 
     return false;
 }

--- a/sdfg/src/types/utils.cpp
+++ b/sdfg/src/types/utils.cpp
@@ -253,7 +253,7 @@ bool is_contiguous_type(const types::IType& base_type, StructuredSDFG& sdfg) {
     return true;
 }
 
-PrimitiveType get_primitive_type_to_hold_expression(const symbolic::Expression& expr) {
+PrimitiveType get_primitive_type_to_hold_upper_bound(const symbolic::Expression& expr) {
     static auto int32_bound = symbolic::integer(INT32_MAX);
 
     if (symbolic::is_true(symbolic::Le(expr, int32_bound))) {
@@ -261,6 +261,78 @@ PrimitiveType get_primitive_type_to_hold_expression(const symbolic::Expression& 
     } else {
         return Int64;
     }
+}
+
+PrimitiveType get_primitive_type_to_hold_lower_bound(const symbolic::Expression& expr) {
+    static auto int32_bound = symbolic::integer(INT32_MIN);
+
+    if (symbolic::is_true(symbolic::Ge(expr, int32_bound))) {
+        return Int32;
+    } else {
+        return Int64;
+    }
+}
+
+PrimitiveType get_primitive_type_to_hold(PrimitiveType a, PrimitiveType b) {
+    // Describe each supported integer type by its bit width and signedness.
+    auto bit_width = [](types::PrimitiveType t) -> int {
+        switch (t) {
+            case types::PrimitiveType::Int32:
+            case types::PrimitiveType::UInt32:
+                return 32;
+            case types::PrimitiveType::Int64:
+            case types::PrimitiveType::UInt64:
+                return 64;
+            default:
+                throw std::invalid_argument("Cannot handle " + std::string(types::primitive_type_to_string(t)));
+        }
+    };
+    auto is_signed = [](types::PrimitiveType t) -> bool {
+        switch (t) {
+            case types::PrimitiveType::Int32:
+            case types::PrimitiveType::Int64:
+                return true;
+            case types::PrimitiveType::UInt32:
+            case types::PrimitiveType::UInt64:
+                return false;
+            default:
+                throw std::invalid_argument("Cannot handle " + std::string(types::primitive_type_to_string(t)));
+        }
+    };
+
+    // Can every value of `src` be extended into `dst` without any loss?
+    auto fits_in = [&](types::PrimitiveType src, types::PrimitiveType dst) -> bool {
+        const int src_bits = bit_width(src);
+        const int dst_bits = bit_width(dst);
+        const bool src_signed = is_signed(src);
+        const bool dst_signed = is_signed(dst);
+
+        if (src_signed == dst_signed) {
+            // Same signedness: the destination just needs to be at least as wide.
+            return dst_bits >= src_bits;
+        }
+        // not safe in general, as we may loose overflows
+        return false;
+    };
+
+    // Candidates ordered from smallest to largest capacity so the first match is
+    // the tightest common type that both operands extend into without loss.
+    static constexpr types::PrimitiveType candidates[] = {
+        types::PrimitiveType::Int32,
+        types::PrimitiveType::UInt32,
+        types::PrimitiveType::Int64,
+        types::PrimitiveType::UInt64,
+    };
+    for (auto candidate : candidates) {
+        if (fits_in(a, candidate) && fits_in(b, candidate)) {
+            return candidate;
+        }
+    }
+
+    throw std::invalid_argument(
+        "Cannot combine types " + std::string(types::primitive_type_to_string(a)) + " and " +
+        types::primitive_type_to_string(b) + " without loss"
+    );
 }
 
 } // namespace types

--- a/sdfg/tests/analysis/loop_analysis_test.cpp
+++ b/sdfg/tests/analysis/loop_analysis_test.cpp
@@ -353,7 +353,7 @@ TEST(LoopAnalysisTest, ancestors_outermost) {
 TEST(LoopAnalysisTest, outermost_loops) {
     builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     builder.add_container("i_1", desc_symbols);
     builder.add_container("i_2", desc_symbols);
     builder.add_container("i_3", desc_symbols);

--- a/sdfg/tests/analysis/memory_layout_analysis_test.cpp
+++ b/sdfg/tests/analysis/memory_layout_analysis_test.cpp
@@ -2356,8 +2356,9 @@ TEST(MemoryLayoutAnalysisTest, TileGroups_TiledTwoAccesses) {
 TEST(MemoryLayoutAnalysisTest, LU_Factorization_Diagnostic) {
     builder::StructuredSDFGBuilder builder("lu_mla", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
-    builder.add_container("N", sym_desc, true);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
+    types::Scalar usym_desc(types::PrimitiveType::UInt64);
+    builder.add_container("N", usym_desc, true);
     builder.add_container("i", sym_desc);
     builder.add_container("j", sym_desc);
     builder.add_container("k", sym_desc);
@@ -2599,8 +2600,9 @@ TEST(MemoryLayoutAnalysisTest, LU_Factorization_Diagnostic) {
 TEST(MemoryLayoutAnalysisTest, LU_BlockedFactorization_Diagnostic) {
     builder::StructuredSDFGBuilder builder("lu_blocked_mla", FunctionType_CPU);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
-    builder.add_container("N", sym_desc, true);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
+    types::Scalar usym_desc(types::PrimitiveType::UInt64);
+    builder.add_container("N", usym_desc, true);
     builder.add_container("i_tile0", sym_desc);
     builder.add_container("i", sym_desc);
     builder.add_container("j", sym_desc);

--- a/sdfg/tests/builder/structured_sdfg_builder_test.cpp
+++ b/sdfg/tests/builder/structured_sdfg_builder_test.cpp
@@ -242,6 +242,8 @@ TEST(StructuredSDFGBuilderTest, addFor) {
     auto& root = builder.subject().root();
     EXPECT_EQ(root.element_id(), 0);
 
+    builder.add_container("i", types::Scalar(types::PrimitiveType::Int64));
+
     auto& scope = builder.add_for(
         root,
         symbolic::symbol("i"),
@@ -273,6 +275,8 @@ TEST(StructuredSDFGBuilderTest, addMap) {
 
     auto& root = builder.subject().root();
     EXPECT_EQ(root.element_id(), 0);
+
+    builder.add_container("i", types::Scalar(types::PrimitiveType::Int64));
 
     auto& scope = builder.add_map(
         root,

--- a/sdfg/tests/cutouts/cutouts_test.cpp
+++ b/sdfg/tests/cutouts/cutouts_test.cpp
@@ -31,7 +31,7 @@ protected:
         builder_->add_container("B", desc_2, true);
         builder_->add_container("C", desc_2, true);
 
-        types::Scalar sym_desc(types::PrimitiveType::UInt64);
+        types::Scalar sym_desc(types::PrimitiveType::Int64);
         builder_->add_container("K", sym_desc, true);
         builder_->add_container("N", sym_desc, true);
         builder_->add_container("M", sym_desc, true);
@@ -158,7 +158,7 @@ TEST(CutoutTest_External, ExternalAndArgumentDoNotCollide) {
     builder.add_container("C", float_desc, true);
 
     // Loop induction variable + bound.
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 

--- a/sdfg/tests/data_flow/library_nodes/math/blas/blas_test.cpp
+++ b/sdfg/tests/data_flow/library_nodes/math/blas/blas_test.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <cstdint>
+
 #include "sdfg/analysis/analysis.h"
 #include "sdfg/builder/structured_sdfg_builder.h"
 #include "sdfg/data_flow/library_nodes/math/blas/batched_gemm_node.h"
@@ -120,9 +122,11 @@ TEST(BlasTest, GemmNode) {
     // ---- Init nest: for i, j: C[i,j] = beta * C[i,j] ----
     auto init_map_i = dyn_cast<structured_control_flow::Map*>(&new_sequence->at(0));
     ASSERT_NE(init_map_i, nullptr);
+    EXPECT_EQ(sdfg.type(init_map_i->indvar()->get_name()).primitive_type(), types::PrimitiveType::Int32);
     ASSERT_EQ(init_map_i->root().size(), 1);
     auto init_map_j = dyn_cast<structured_control_flow::Map*>(&init_map_i->root().at(0));
     ASSERT_NE(init_map_j, nullptr);
+    EXPECT_EQ(sdfg.type(init_map_j->indvar()->get_name()).primitive_type(), types::PrimitiveType::Int32);
     ASSERT_EQ(init_map_j->root().size(), 1);
     {
         auto block_init = dyn_cast<structured_control_flow::Block*>(&init_map_j->root().at(0));
@@ -137,12 +141,15 @@ TEST(BlasTest, GemmNode) {
     // ---- Compute nest: for i, j, k: C[i,j] = alpha * A[i,k] * B[k,j] + C[i,j] ----
     auto comp_map_i = dyn_cast<structured_control_flow::Map*>(&new_sequence->at(1));
     ASSERT_NE(comp_map_i, nullptr);
+    EXPECT_EQ(sdfg.type(comp_map_i->indvar()->get_name()).primitive_type(), types::PrimitiveType::Int32);
     ASSERT_EQ(comp_map_i->root().size(), 1);
     auto comp_map_j = dyn_cast<structured_control_flow::Map*>(&comp_map_i->root().at(0));
     ASSERT_NE(comp_map_j, nullptr);
+    EXPECT_EQ(sdfg.type(comp_map_j->indvar()->get_name()).primitive_type(), types::PrimitiveType::Int32);
     ASSERT_EQ(comp_map_j->root().size(), 1);
     auto comp_for_k = dyn_cast<structured_control_flow::For*>(&comp_map_j->root().at(0));
     ASSERT_NE(comp_for_k, nullptr);
+    EXPECT_EQ(sdfg.type(comp_for_k->indvar()->get_name()).primitive_type(), types::PrimitiveType::Int32);
     ASSERT_EQ(comp_for_k->root().size(), 1);
     {
         auto block_fma = dyn_cast<structured_control_flow::Block*>(&comp_for_k->root().at(0));
@@ -171,6 +178,7 @@ TEST(BlasTest, GemmNode) {
         ASSERT_EQ(final_access->data(), c_var_name);
     }
 }
+
 
 TEST(BlasTest, GemmNode_AlphaOneBetaZero) {
     builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
@@ -636,3 +644,156 @@ TEST(BlasTest, BatchedGemmNode_AlphaOneBetaZero) {
     EXPECT_NE(final_access, nullptr);
     EXPECT_EQ(final_access->data(), c_var_name);
 }
+
+// ---------------------------------------------------------------------------
+// Parameterized GEMM expansion test focused on the induction-variable types.
+//
+// The expansion picks each loop's index type from its dimension bound via
+// types::get_primitive_type_to_hold_expression: bounds that fit in INT32_MAX
+// stay Int32, everything larger (beyond Int32 *and* beyond UInt32) becomes
+// Int64. The i/j/k induction variables come from m/n/k respectively, so mixing
+// the dimension magnitudes lets each index resolve to a different width.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Reference thresholds for readable parameter values.
+constexpr int64_t kInt32Max = INT32_MAX; // 2^31 - 1
+constexpr int64_t kUInt32Max = UINT32_MAX; // 2^32 - 1
+constexpr int64_t kAboveInt32 = kInt32Max + 1; // 2^31, no longer fits Int32
+constexpr int64_t kAboveUInt32 = kUInt32Max + 1; // 2^32, beyond UInt32 too
+
+struct GemmIndvarTypeParams {
+    std::string label;
+    int64_t dim_i; // -> i induction variable (from m)
+    int64_t dim_j; // -> j induction variable (from n)
+    int64_t dim_k; // -> k induction variable (from k)
+    types::PrimitiveType expected_i;
+    types::PrimitiveType expected_j;
+    types::PrimitiveType expected_k;
+};
+
+class GemmNodeIndvarTypeTest : public ::testing::TestWithParam<GemmIndvarTypeParams> {};
+
+TEST_P(GemmNodeIndvarTypeTest, ExpandedIndvarTypesMatchDimensionMagnitude) {
+    const auto& p = GetParam();
+
+    builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
+    auto& sdfg = builder.subject();
+
+    auto m = symbolic::integer(p.dim_i);
+    auto n = symbolic::integer(p.dim_j);
+    auto k = symbolic::integer(p.dim_k);
+
+    // res: ixj, A: ixk, B: kxj. Sizes are symbolic (arbitrary precision), so
+    // huge dimensions do not overflow the container descriptors.
+    types::Scalar desc(types::PrimitiveType::Float);
+    types::Array arr_a_type(desc, symbolic::mul(k, m));
+    types::Array arr_b_type(desc, symbolic::mul(n, k));
+    types::Array arr_res_type(desc, symbolic::mul(n, m));
+
+    builder.add_container("arr_a", arr_a_type);
+    builder.add_container("arr_b", arr_b_type);
+    builder.add_container("output", arr_res_type);
+
+    auto& block = builder.add_block(sdfg.root());
+
+    auto& input_a_node = builder.add_access(block, "arr_a");
+    auto& input_b_node = builder.add_access(block, "arr_b");
+    auto& dummy_input_node = builder.add_access(block, "output");
+    auto& gemm_node = static_cast<math::blas::GEMMNode&>(builder.add_library_node<math::blas::GEMMNode>(
+        block,
+        DebugInfo(),
+        data_flow::ImplementationType_NONE,
+        math::blas::BLAS_Precision::s,
+        math::blas::BLAS_Layout::RowMajor,
+        math::blas::BLAS_Transpose::No,
+        math::blas::BLAS_Transpose::No,
+        m,
+        n,
+        k,
+        n, // lda
+        k, // ldb
+        n // ldc
+    ));
+
+    // Non-special alpha/beta so both the init and compute nests are generated.
+    auto& alpha_node = builder.add_constant(block, "2.0", desc);
+    auto& beta_node = builder.add_constant(block, "3.0", desc);
+
+    builder.add_computational_memlet(block, input_a_node, gemm_node, "__A", {symbolic::integer(0)}, arr_a_type);
+    builder.add_computational_memlet(block, input_b_node, gemm_node, "__B", {symbolic::integer(0)}, arr_b_type);
+    builder.add_computational_memlet(block, dummy_input_node, gemm_node, "__C", {symbolic::integer(0)}, arr_res_type);
+    builder.add_computational_memlet(block, alpha_node, gemm_node, "__alpha", {}, desc);
+    builder.add_computational_memlet(block, beta_node, gemm_node, "__beta", {}, desc);
+
+    builder.subject().validate();
+    auto outcome = passes::expansion::expand_single_math_node(builder, block, gemm_node);
+    ASSERT_TRUE(outcome.expanded);
+    dump_sdfg(builder.subject(), "1.expanded");
+    ASSERT_TRUE(outcome.block_removed);
+    builder.subject().validate();
+
+    ASSERT_EQ(sdfg.root().size(), 1);
+    auto new_sequence = dyn_cast<structured_control_flow::Sequence*>(&sdfg.root().at(0));
+    ASSERT_NE(new_sequence, nullptr);
+    // beta != 1 => [init nest, compute nest]; the compute nest carries all three
+    // (i, j, k) induction variables, so it is enough to inspect it.
+    ASSERT_EQ(new_sequence->size(), 2);
+
+    auto comp_map_i = dyn_cast<structured_control_flow::Map*>(&new_sequence->at(1));
+    ASSERT_NE(comp_map_i, nullptr);
+    auto comp_map_j = dyn_cast<structured_control_flow::Map*>(&comp_map_i->root().at(0));
+    ASSERT_NE(comp_map_j, nullptr);
+    auto comp_for_k = dyn_cast<structured_control_flow::For*>(&comp_map_j->root().at(0));
+    ASSERT_NE(comp_for_k, nullptr);
+
+    EXPECT_EQ(sdfg.type(comp_map_i->indvar()->get_name()).primitive_type(), p.expected_i);
+    EXPECT_EQ(sdfg.type(comp_map_j->indvar()->get_name()).primitive_type(), p.expected_j);
+    EXPECT_EQ(sdfg.type(comp_for_k->indvar()->get_name()).primitive_type(), p.expected_k);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BlasTest,
+    GemmNodeIndvarTypeTest,
+    ::testing::Values(
+        // All dimensions small: every index fits in Int32.
+        GemmIndvarTypeParams{
+            "AllInt32", 10, 20, 30, types::PrimitiveType::Int32, types::PrimitiveType::Int32, types::PrimitiveType::Int32
+        },
+        // One dimension just past Int32 (still within UInt32) -> that index is
+        // promoted to Int64, the others stay Int32. Magnitudes are mixed.
+        GemmIndvarTypeParams{
+            "MixedAboveInt32",
+            kAboveInt32,
+            20,
+            30,
+            types::PrimitiveType::Int64,
+            types::PrimitiveType::Int32,
+            types::PrimitiveType::Int32
+        },
+        // Mix of "> Int32" and "> UInt32": both promote to Int64, small stays Int32.
+        GemmIndvarTypeParams{
+            "MixedAboveUInt32",
+            kAboveUInt32,
+            kAboveInt32,
+            30,
+            types::PrimitiveType::Int64,
+            types::PrimitiveType::Int64,
+            types::PrimitiveType::Int32
+        },
+        // Fully mixed across the three regimes: small / > Int32 / > UInt32.
+        GemmIndvarTypeParams{
+            "MixedAllRegimes",
+            10,
+            kAboveInt32,
+            kAboveUInt32,
+            types::PrimitiveType::Int32,
+            types::PrimitiveType::Int64,
+            types::PrimitiveType::Int64
+        }
+    ),
+    [](const ::testing::TestParamInfo<GemmIndvarTypeParams>& info) { return info.param.label; }
+);
+
+} // namespace

--- a/sdfg/tests/data_flow/library_nodes/math/tensor/einsum_test.cpp
+++ b/sdfg/tests/data_flow/library_nodes/math/tensor/einsum_test.cpp
@@ -287,6 +287,7 @@ TEST(EinsumNodeTest, SimpleMeans) {
     builder.add_container("A", desc_m, true);
     builder.add_container("y", desc, true);
     builder.add_container("m_tmp", base_desc);
+    builder.add_container("i", sym_desc);
 
     // Symbols
     auto zero = symbolic::zero();
@@ -403,6 +404,7 @@ TEST(EinsumNodeTest, ExpandMeans) {
     builder.add_container("A", desc_m, true);
     builder.add_container("y", desc, true);
     builder.add_container("m_tmp", base_desc);
+    builder.add_container("i", sym_desc);
 
     // Symbols
     auto zero = symbolic::zero();

--- a/sdfg/tests/data_flow/library_nodes/math/tensor/elementwise_test.cpp
+++ b/sdfg/tests/data_flow/library_nodes/math/tensor/elementwise_test.cpp
@@ -27,7 +27,7 @@
 using namespace sdfg;
 
 template<typename NodeType, typename... Args>
-void TestUnary(std::vector<size_t> shape_dims, Args&&... args) {
+void TestUnary(std::vector<size_t> shape_dims, types::PrimitiveType expected_indvar_type, Args&&... args) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
     auto& sdfg = builder.subject();
 
@@ -73,6 +73,8 @@ void TestUnary(std::vector<size_t> shape_dims, Args&&... args) {
     for (size_t i = 0; i < shape_dims.size(); ++i) {
         auto map_loop = dyn_cast<structured_control_flow::Map*>(&current_scope->at(0));
         ASSERT_NE(map_loop, nullptr);
+        EXPECT_EQ(sdfg.type(map_loop->indvar()->get_name()).primitive_type(), expected_indvar_type)
+            << "Expect indvar to have type fitting dimension";
         current_scope = &map_loop->root();
     }
 
@@ -123,7 +125,7 @@ void TestUnary(std::vector<size_t> shape_dims, Args&&... args) {
 }
 
 template<typename NodeType>
-void TestBinary(std::vector<size_t> shape_dims) {
+void TestBinary(std::vector<size_t> shape_dims, types::PrimitiveType expected_indvar_type) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
     auto& sdfg = builder.subject();
 
@@ -165,6 +167,8 @@ void TestBinary(std::vector<size_t> shape_dims) {
     for (size_t i = 0; i < shape_dims.size(); ++i) {
         auto map_loop = dyn_cast<structured_control_flow::Map*>(&current_scope->at(0));
         ASSERT_NE(map_loop, nullptr);
+        EXPECT_EQ(sdfg.type(map_loop->indvar()->get_name()).primitive_type(), expected_indvar_type)
+            << "Expect indvar to have type fitting dimension";
         current_scope = &map_loop->root();
     }
 
@@ -202,25 +206,25 @@ void TestBinary(std::vector<size_t> shape_dims) {
     }
 }
 
-#define REGISTER_UNARY_TEST(NodeType, Dim)                \
-    TEST(ElementWiseTest, NodeType##_##Dim##D) {          \
-        std::vector<size_t> dims;                         \
-        for (int i = 0; i < Dim; ++i) dims.push_back(32); \
-        TestUnary<math::tensor::NodeType>(dims);          \
+#define REGISTER_UNARY_TEST(NodeType, Dim)                                    \
+    TEST(ElementWiseTest, NodeType##_##Dim##D) {                              \
+        std::vector<size_t> dims;                                             \
+        for (int i = 0; i < Dim; ++i) dims.push_back(32);                     \
+        TestUnary<math::tensor::NodeType>(dims, types::PrimitiveType::Int32); \
     }
 
-#define REGISTER_UNARY_TEST_OPT(NodeType, Dim, Opt)       \
-    TEST(ElementWiseTest, NodeType##_##Dim##D) {          \
-        std::vector<size_t> dims;                         \
-        for (int i = 0; i < Dim; ++i) dims.push_back(32); \
-        TestUnary<math::tensor::NodeType>(dims, Opt);     \
+#define REGISTER_UNARY_TEST_OPT(NodeType, Dim, Opt)                                \
+    TEST(ElementWiseTest, NodeType##_##Dim##D) {                                   \
+        std::vector<size_t> dims;                                                  \
+        for (int i = 0; i < Dim; ++i) dims.push_back(32);                          \
+        TestUnary<math::tensor::NodeType>(dims, types::PrimitiveType::Int32, Opt); \
     }
 
-#define REGISTER_BINARY_TEST(NodeType, Dim)               \
-    TEST(ElementWiseTest, NodeType##_##Dim##D) {          \
-        std::vector<size_t> dims;                         \
-        for (int i = 0; i < Dim; ++i) dims.push_back(32); \
-        TestBinary<math::tensor::NodeType>(dims);         \
+#define REGISTER_BINARY_TEST(NodeType, Dim)                                    \
+    TEST(ElementWiseTest, NodeType##_##Dim##D) {                               \
+        std::vector<size_t> dims;                                              \
+        for (int i = 0; i < Dim; ++i) dims.push_back(32);                      \
+        TestBinary<math::tensor::NodeType>(dims, types::PrimitiveType::Int32); \
     }
 
 // Unary Tests

--- a/sdfg/tests/data_flow/library_nodes/math/tensor/reduce_test.cpp
+++ b/sdfg/tests/data_flow/library_nodes/math/tensor/reduce_test.cpp
@@ -96,6 +96,7 @@ TEST(ReduceTest, SumNode_1D) {
     {
         auto sum_loop = dyn_cast<structured_control_flow::Reduce*>(&new_sequence.at(1));
         EXPECT_NE(sum_loop, nullptr);
+        EXPECT_EQ(sdfg.type(sum_loop->indvar()->get_name()).primitive_type(), types::PrimitiveType::Int32);
         EXPECT_EQ(sum_loop->root().size(), 1);
 
         auto reduce_block = dyn_cast<structured_control_flow::Block*>(&sum_loop->root().at(0));
@@ -188,6 +189,7 @@ TEST(ReduceTest, SumNode_2D) {
         EXPECT_NE(map_loop, nullptr);
 
         auto for_loop = dyn_cast<structured_control_flow::Reduce*>(&map_loop->root().at(0));
+        EXPECT_EQ(sdfg.type(for_loop->indvar()->get_name()).primitive_type(), types::PrimitiveType::Int32);
         EXPECT_NE(for_loop, nullptr);
 
         auto reduce_block = dyn_cast<structured_control_flow::Block*>(&for_loop->root().at(0));
@@ -257,9 +259,11 @@ TEST(ReduceTest, SumNode_2D_KeepDims) {
     // Inner loop: dim 1 (For)
     {
         auto map_loop = dyn_cast<structured_control_flow::Map*>(&new_sequence.at(1));
+        EXPECT_EQ(sdfg.type(map_loop->indvar()->get_name()).primitive_type(), types::PrimitiveType::Int32);
         EXPECT_NE(map_loop, nullptr);
 
         auto for_loop = dyn_cast<structured_control_flow::Reduce*>(&map_loop->root().at(0));
+        EXPECT_EQ(sdfg.type(for_loop->indvar()->get_name()).primitive_type(), types::PrimitiveType::Int32);
         EXPECT_NE(for_loop, nullptr);
 
         auto reduce_block = dyn_cast<structured_control_flow::Block*>(&for_loop->root().at(0));
@@ -331,12 +335,15 @@ TEST(ReduceTest, SumNode_3D_Reduce_0_2) {
     // Inner loops: dim 0 (For), dim 2 (For)
     {
         auto map_loop = dyn_cast<structured_control_flow::Map*>(&new_sequence.at(1));
+        EXPECT_EQ(sdfg.type(map_loop->indvar()->get_name()).primitive_type(), types::PrimitiveType::Int32);
         EXPECT_NE(map_loop, nullptr);
 
         auto for_loop_0 = dyn_cast<structured_control_flow::Reduce*>(&map_loop->root().at(0));
+        EXPECT_EQ(sdfg.type(for_loop_0->indvar()->get_name()).primitive_type(), types::PrimitiveType::Int32);
         EXPECT_NE(for_loop_0, nullptr);
 
         auto for_loop_2 = dyn_cast<structured_control_flow::Reduce*>(&for_loop_0->root().at(0));
+        EXPECT_EQ(sdfg.type(for_loop_2->indvar()->get_name()).primitive_type(), types::PrimitiveType::Int32);
         EXPECT_NE(for_loop_2, nullptr);
 
         auto reduce_block = dyn_cast<structured_control_flow::Block*>(&for_loop_2->root().at(0));

--- a/sdfg/tests/passes/dataflow/constant_propagation_test.cpp
+++ b/sdfg/tests/passes/dataflow/constant_propagation_test.cpp
@@ -75,7 +75,7 @@ bool reads_container(structured_control_flow::Block& block, const std::string& n
 }
 
 symbolic::Symbol add_index(builder::StructuredSDFGBuilder& builder, const std::string& name) {
-    builder.add_container(name, types::Scalar(types::PrimitiveType::UInt64));
+    builder.add_container(name, types::Scalar(types::PrimitiveType::Int64));
     return symbolic::symbol(name);
 }
 

--- a/sdfg/tests/passes/dataflow/dead_data_elimination_test.cpp
+++ b/sdfg/tests/passes/dataflow/dead_data_elimination_test.cpp
@@ -23,7 +23,7 @@ using namespace sdfg;
 TEST(DeadDataEliminationTest, Unused) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar desc(types::PrimitiveType::UInt32);
+    types::Scalar desc(types::PrimitiveType::Int32);
     builder.add_container("i", desc);
     auto sdfg = builder.move();
 
@@ -45,7 +45,7 @@ TEST(DeadDataEliminationTest, Unused) {
 TEST(DeadDataEliminationTest, WriteWithoutRead_Transition) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar desc(types::PrimitiveType::UInt32);
+    types::Scalar desc(types::PrimitiveType::Int32);
     builder.add_container("i", desc);
     auto sym1 = symbolic::symbol("i");
 
@@ -76,7 +76,7 @@ TEST(DeadDataEliminationTest, WriteWithoutRead_Transition) {
 TEST(DeadDataEliminationTest, WriteWithoutRead_Dataflow) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar desc(types::PrimitiveType::UInt32);
+    types::Scalar desc(types::PrimitiveType::Int32);
     builder.add_container("j", desc);
 
     auto& root = builder.subject().root();
@@ -175,7 +175,7 @@ TEST(DeadDataEliminationTest, Does_not_remove_some_libNode_outputs) {
 TEST(DeadDataEliminationTest, WriteAfterWrite_For) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar desc(types::PrimitiveType::UInt32);
+    types::Scalar desc(types::PrimitiveType::Int32);
     builder.add_container("i", desc);
     auto sym = symbolic::symbol("i");
 
@@ -634,7 +634,7 @@ TEST(DeadDataEliminationTest, DanglingRead) {
 TEST(DeadDataEliminationTest, OwnedHeapMemoryIsRemoved) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar t_int_desc(types::PrimitiveType::UInt32);
+    types::Scalar t_int_desc(types::PrimitiveType::Int32);
     types::Scalar t_fp_desc(types::PrimitiveType::Float);
     types::Pointer t_fp_ptr(t_fp_desc);
 
@@ -704,7 +704,7 @@ TEST(DeadDataEliminationTest, OwnedHeapMemoryIsRemoved) {
 TEST(DeadDataEliminationTest, OwnedHeapMemoryWithFree) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar t_int_desc(types::PrimitiveType::UInt32);
+    types::Scalar t_int_desc(types::PrimitiveType::Int32);
     types::Scalar t_fp_desc(types::PrimitiveType::Float);
     types::Pointer t_fp_ptr(t_fp_desc);
 
@@ -779,7 +779,7 @@ TEST(DeadDataEliminationTest, OwnedHeapMemoryWithFree) {
 TEST(DeadDataEliminationTest, MultiWrittenOwnedHeapMemoryIsRemoved) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar t_int_desc(types::PrimitiveType::UInt32);
+    types::Scalar t_int_desc(types::PrimitiveType::Int32);
     types::Scalar t_fp_desc(types::PrimitiveType::Float);
     types::Pointer t_fp_ptr(t_fp_desc);
 
@@ -847,7 +847,7 @@ TEST(DeadDataEliminationTest, MultiWrittenOwnedHeapMemoryIsRemoved) {
 TEST(DeadDataEliminationTest, OwnedHeapMemoryPtrEscapedViaReturn) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar t_int_desc(types::PrimitiveType::UInt32);
+    types::Scalar t_int_desc(types::PrimitiveType::Int32);
     types::Scalar t_fp_desc(types::PrimitiveType::Float);
     types::Pointer t_fp_ptr(t_fp_desc);
 
@@ -918,7 +918,7 @@ TEST(DeadDataEliminationTest, OwnedHeapMemoryPtrEscapedViaReturn) {
 TEST(DeadDataEliminationTest, OwnedHeapMemorySubsetAddrEscapedViaReturn) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar t_int_desc(types::PrimitiveType::UInt32);
+    types::Scalar t_int_desc(types::PrimitiveType::Int32);
     types::Scalar t_fp_desc(types::PrimitiveType::Float);
     types::Pointer t_fp_ptr(t_fp_desc);
 
@@ -996,7 +996,7 @@ TEST(DeadDataEliminationTest, OwnedHeapMemorySubsetAddrEscapedViaReturn) {
 TEST(DeadDataEliminationTest, OwnedHeapMemoryEscapesViaPtrWrite) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar t_int_desc(types::PrimitiveType::UInt32);
+    types::Scalar t_int_desc(types::PrimitiveType::Int32);
     types::Scalar t_fp_desc(types::PrimitiveType::Float);
     types::Pointer t_fp_ptr(t_fp_desc);
     types::Pointer t_fp_ptr_ptr(reinterpret_cast<types::IType&>(t_fp_ptr));
@@ -1072,7 +1072,7 @@ TEST(DeadDataEliminationTest, OwnedHeapMemoryEscapesViaPtrWrite) {
 TEST(DeadDataEliminationTest, OwnedHeapMemoryEscapesViaBlackbox) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar t_int_desc(types::PrimitiveType::UInt32);
+    types::Scalar t_int_desc(types::PrimitiveType::Int32);
     types::Scalar t_fp_desc(types::PrimitiveType::Float);
     types::Pointer t_fp_ptr(t_fp_desc);
     types::Pointer t_fp_ptr_ptr(reinterpret_cast<types::IType&>(t_fp_ptr));
@@ -1154,7 +1154,7 @@ TEST(DeadDataEliminationTest, OwnedHeapMemoryEscapesViaBlackbox) {
 TEST(DeadDataEliminationTest, OwnedHeapMemoryEscapesViaTasklet) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar t_int_desc(types::PrimitiveType::UInt32);
+    types::Scalar t_int_desc(types::PrimitiveType::Int32);
     types::Scalar t_int64_desc(types::PrimitiveType::UInt64);
     types::Scalar t_fp_desc(types::PrimitiveType::Float);
     types::Pointer t_fp_ptr(t_fp_desc);
@@ -1237,7 +1237,7 @@ TEST(DeadDataEliminationTest, OwnedHeapMemoryEscapesViaTasklet) {
 TEST(DeadDataEliminationTest, OwnedHeapMemoryEscapesViaSymbol) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar t_int_desc(types::PrimitiveType::UInt32);
+    types::Scalar t_int_desc(types::PrimitiveType::Int32);
     types::Scalar t_int64_desc(types::PrimitiveType::UInt64);
     types::Scalar t_fp_desc(types::PrimitiveType::Float);
     types::Pointer t_fp_ptr(t_fp_desc);
@@ -1334,7 +1334,7 @@ TEST(DeadDataEliminationTest, OwnedHeapMemoryEscapesViaSymbol) {
 TEST(DeadDataEliminationTest, OwnedHeapMemoryElementRead) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar t_int_desc(types::PrimitiveType::UInt32);
+    types::Scalar t_int_desc(types::PrimitiveType::Int32);
     types::Scalar t_int64_desc(types::PrimitiveType::UInt64);
     types::Scalar t_fp_desc(types::PrimitiveType::Float);
     types::Pointer t_fp_ptr(t_fp_desc);

--- a/sdfg/tests/passes/dataflow/memlet_simplification_test.cpp
+++ b/sdfg/tests/passes/dataflow/memlet_simplification_test.cpp
@@ -48,7 +48,7 @@ TEST(MemletSimplification, SimplifyTwoDimensional) {
 
     builder.add_container("source", opaque_ptr);
     builder.add_container("arr", opaque_ptr);
-    builder.add_container("idx", types::Scalar(types::PrimitiveType::UInt64));
+    builder.add_container("idx", types::Scalar(types::PrimitiveType::Int64));
 
     auto idx = symbolic::symbol("idx");
     auto& root = builder.subject().root();
@@ -88,7 +88,7 @@ TEST(MemletSimplification, SimplifyThreeDimensional) {
 
     builder.add_container("source", opaque_ptr);
     builder.add_container("arr", opaque_ptr);
-    builder.add_container("idx", types::Scalar(types::PrimitiveType::UInt64));
+    builder.add_container("idx", types::Scalar(types::PrimitiveType::Int64));
 
     auto idx = symbolic::symbol("idx");
     auto& root = builder.subject().root();
@@ -131,7 +131,7 @@ TEST(MemletSimplification, SimplifyFourDimensionalReLU) {
 
     builder.add_container("source", opaque_ptr);
     builder.add_container("arr", opaque_ptr);
-    builder.add_container("idx", types::Scalar(types::PrimitiveType::UInt64));
+    builder.add_container("idx", types::Scalar(types::PrimitiveType::Int64));
 
     auto idx = symbolic::symbol("idx");
     auto& root = builder.subject().root();

--- a/sdfg/tests/passes/dataflow/reference_propagation_test.cpp
+++ b/sdfg/tests/passes/dataflow/reference_propagation_test.cpp
@@ -568,6 +568,7 @@ TEST(ReferencePropagationTest, ReferenceUsedInsideForLoop) {
 
     // For loop: for (i = 0; i < N; i++)
     auto i = symbolic::symbol("i");
+    builder.add_container("i", types::Scalar(types::PrimitiveType::Int64));
     auto N = symbolic::symbol("N");
     auto& loop =
         builder.add_for(root, i, symbolic::Lt(i, N), symbolic::integer(0), symbolic::add(i, symbolic::integer(1)));

--- a/sdfg/tests/passes/structured_control_flow/condition_elimination_test.cpp
+++ b/sdfg/tests/passes/structured_control_flow/condition_elimination_test.cpp
@@ -22,7 +22,7 @@ TEST(ConditionEliminationTest, Basic) {
     builder.add_container("A", opaque_desc, true);
     builder.add_container("B", opaque_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -83,7 +83,7 @@ TEST(ConditionEliminationTest, Basic_WithAssignmentsAfterLoop) {
     builder.add_container("A", opaque_desc, true);
     builder.add_container("B", opaque_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -151,7 +151,7 @@ TEST(ConditionEliminationTest, Basic_LeavesAfterAlone) {
     builder.add_container("A", opaque_desc, true);
     builder.add_container("B", opaque_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -219,7 +219,7 @@ TEST(ConditionEliminationTest, IndvarReadAfterLoop) {
     builder.add_container("A", opaque_desc, true);
     builder.add_container("B", opaque_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 

--- a/sdfg/tests/passes/structured_control_flow/dead_cfg_elimination_test.cpp
+++ b/sdfg/tests/passes/structured_control_flow/dead_cfg_elimination_test.cpp
@@ -133,7 +133,7 @@ TEST(DeadCFGEliminationTest, NonTrivialMap) {
     // Test non-trivial loop: for (i = 0; i < 10; i++) - should NOT be eliminated
     builder::StructuredSDFGBuilder builder("sdfg_1", FunctionType_CPU);
 
-    types::Scalar int_type(types::PrimitiveType::UInt64);
+    types::Scalar int_type(types::PrimitiveType::Int64);
     builder.add_container("i", int_type);
 
     auto& root = builder.subject().root();

--- a/sdfg/tests/passes/structured_control_flow/for_classification_test.cpp
+++ b/sdfg/tests/passes/structured_control_flow/for_classification_test.cpp
@@ -26,7 +26,7 @@ TEST(ForClassificationTest, Basic) {
     builder.add_container("A", opaque_desc, true);
     builder.add_container("B", opaque_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -77,7 +77,7 @@ TEST(ForClassificationTest, MultiBound) {
     builder.add_container("A", opaque_desc, true);
     builder.add_container("B", opaque_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("M", sym_desc, true);
     builder.add_container("i", sym_desc);
@@ -129,7 +129,7 @@ TEST(ForClassificationTest, NonContiguousDomain) {
     builder.add_container("A", opaque_desc, true);
     builder.add_container("B", opaque_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -180,7 +180,7 @@ TEST(ForClassificationTest, NonCanonicalBound) {
     builder.add_container("A", opaque_desc, true);
     builder.add_container("B", opaque_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -231,7 +231,7 @@ TEST(ForClassificationTest, Shift) {
     builder.add_container("A", opaque_desc, true);
     builder.add_container("B", opaque_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -282,7 +282,7 @@ TEST(ForClassificationTest, LastValue) {
     builder.add_container("A", opaque_desc, true);
     builder.add_container("B", opaque_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -331,7 +331,7 @@ TEST(ForClassificationTest, Tiled) {
     types::Pointer opaque_desc;
     builder.add_container("A", opaque_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
     builder.add_container("i_tile", sym_desc);
@@ -402,7 +402,7 @@ TEST(ForClassificationTest, NonContiguousMemory) {
     builder.add_container("B", opaque_desc);
     builder.add_container("A", opaque_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -456,7 +456,7 @@ TEST(ForClassificationTest, ScalarSumReduction) {
     builder.add_container("A", opaque_desc, true);
     builder.add_container("sum", base_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -511,7 +511,7 @@ TEST(ForClassificationTest, ScalarProductReduction) {
     builder.add_container("A", opaque_desc, true);
     builder.add_container("prod", base_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -562,7 +562,7 @@ TEST(ForClassificationTest, FloatMaxReductionCMath) {
     builder.add_container("A", opaque_desc, true);
     builder.add_container("m", base_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -616,7 +616,7 @@ TEST(ForClassificationTest, FusedSumAndProductReduction) {
     builder.add_container("sum", base_desc, true);
     builder.add_container("prod", base_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -687,7 +687,7 @@ TEST(ForClassificationTest, RecurrenceIsNotReduction) {
     builder.add_container("A", opaque_desc, true);
     builder.add_container("c", base_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 

--- a/sdfg/tests/passes/structured_control_flow/unique_loop_indvars_test.cpp
+++ b/sdfg/tests/passes/structured_control_flow/unique_loop_indvars_test.cpp
@@ -18,7 +18,7 @@ TEST(UniqueLoopIndvarsTest, DistinctIndvars_NoChange) {
 
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
     builder.add_container("j", sym_desc);
@@ -53,7 +53,7 @@ TEST(UniqueLoopIndvarsTest, SiblingLoops_SameIndvar_Renamed) {
 
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -94,7 +94,7 @@ TEST(UniqueLoopIndvarsTest, NestedLoops_SameIndvar_InnerRenamed) {
     builder.add_container("A", pointer_type, true);
     builder.add_container("B", pointer_type);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("M", sym_desc, true);
     builder.add_container("i", sym_desc);
@@ -143,7 +143,7 @@ TEST(UniqueLoopIndvarsTest, NestedMaps_SameIndvar_InnerRenamed) {
 
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("M", sym_desc, true);
     builder.add_container("i", sym_desc);
@@ -191,7 +191,7 @@ TEST(UniqueLoopIndvarsTest, Idempotent) {
 
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("M", sym_desc, true);
     builder.add_container("i", sym_desc);
@@ -224,7 +224,7 @@ TEST(UniqueLoopIndvarsTest, IndvarReadAfterLoop_NotRenamed) {
     builder.add_container("A", pointer_type, true);
     builder.add_container("B", pointer_type, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 

--- a/sdfg/tests/passes/symbolic/symbol_propagation_test.cpp
+++ b/sdfg/tests/passes/symbolic/symbol_propagation_test.cpp
@@ -338,7 +338,7 @@ TEST(SymbolPropagationTest, Transition2IfElse_Negative) {
 TEST(SymbolPropagationTest, Transition2For_Init) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar desc(types::PrimitiveType::UInt32);
+    types::Scalar desc(types::PrimitiveType::Int32);
     builder.add_container("i", desc);
     auto sym = symbolic::symbol("i");
 
@@ -365,7 +365,7 @@ TEST(SymbolPropagationTest, Transition2For_Init) {
 TEST(SymbolPropagationTest, Transition2For_Condition) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar desc(types::PrimitiveType::UInt32);
+    types::Scalar desc(types::PrimitiveType::Int32);
     builder.add_container("i", desc);
     builder.add_container("N", desc);
     auto sym = symbolic::symbol("i");
@@ -394,7 +394,7 @@ TEST(SymbolPropagationTest, Transition2For_Condition) {
 TEST(SymbolPropagationTest, Transition2For_Update) {
     builder::StructuredSDFGBuilder builder("sdfg", FunctionType_CPU);
 
-    types::Scalar desc(types::PrimitiveType::UInt32);
+    types::Scalar desc(types::PrimitiveType::Int32);
     builder.add_container("i", desc);
     builder.add_container("j", desc);
     auto sym = symbolic::symbol("i");

--- a/sdfg/tests/serializer/json_serializer_test.cpp
+++ b/sdfg/tests/serializer/json_serializer_test.cpp
@@ -385,7 +385,7 @@ TEST(JSONSerializerTest, DataflowToJSON) {
     builder.add_container("D", opaque_desc, true);
     builder.add_container("C", base_desc, true);
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 
@@ -480,7 +480,7 @@ TEST(JSONSerializerTest, ForNodeToJSON) {
     sdfg::builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     auto& scope = builder.add_for(
@@ -525,7 +525,7 @@ TEST(JSONSerializerTest, IfElseToJSON) {
     sdfg::builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     auto& if_else = builder.add_if_else(root);
@@ -564,7 +564,7 @@ TEST(JSONSerializerTest, WhileToJSON_break) {
     sdfg::builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     auto& scope = builder.add_while(root);
@@ -596,7 +596,7 @@ TEST(JSONSerializerTest, WhileToJSON_continue) {
     sdfg::builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     auto& scope = builder.add_while(root);
@@ -652,7 +652,7 @@ TEST(JSONSerializerTest, SequenceToJSON) {
     sdfg::builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     auto& scope = builder.add_sequence(root);
@@ -693,7 +693,8 @@ TEST(JSONSerializerTest, MapToJSON) {
     sdfg::builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
+    builder.add_container("i", sym_desc);
 
     auto& map = builder.add_map(
         root,
@@ -737,6 +738,9 @@ TEST(JSONSerializerTest, ReduceToJSON) {
     // Create a sample Reduce node
     sdfg::builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
     auto& root = builder.subject().root();
+
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
+    builder.add_container("i", sym_desc);
 
     auto& reduce = builder.add_reduce(
         root,
@@ -1582,7 +1586,7 @@ TEST(JSONSerializerTest, SerializeDeserialize_ifelse) {
     sdfg::builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     auto& if_else = builder.add_if_else(root);
@@ -1630,7 +1634,7 @@ TEST(JSONSerializerTest, SerializeDeserialize_sequence) {
     sdfg::builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     auto& scope = builder.add_sequence(root);
@@ -1668,7 +1672,7 @@ TEST(JSONSerializerTest, SerializeDeserialize_while) {
     sdfg::builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     auto& scope = builder.add_sequence(root);
@@ -1704,7 +1708,7 @@ TEST(JSONSerializerTest, SerializeDeserialize_while_break) {
     sdfg::builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     auto& scope = builder.add_sequence(root);
@@ -1741,7 +1745,7 @@ TEST(JSONSerializerTest, SerializeDeserialize_while_continue) {
     sdfg::builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
     auto& root = builder.subject().root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("i", sym_desc);
 
     auto& scope = builder.add_sequence(root);
@@ -1777,6 +1781,9 @@ TEST(JSONSerializerTest, SerializeDeserialize_Map) {
     sdfg::builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
     auto& root = builder.subject().root();
 
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
+    builder.add_container("i", sym_desc);
+
     auto& map = builder.add_map(
         root,
         symbolic::symbol("i"),
@@ -1797,11 +1804,12 @@ TEST(JSONSerializerTest, SerializeDeserialize_Map) {
 
     // Deserialize the JSON back into a Sequence node
     auto des_builder = sdfg::builder::StructuredSDFGBuilder("test_sdfg", FunctionType_CPU);
+    des_builder.add_container("i", sym_desc);
 
     serializer.json_to_structured_loop_node(j, des_builder, des_builder.subject().root());
     auto des_sdfg = des_builder.move();
     EXPECT_EQ(des_sdfg->name(), sdfg->name());
-    EXPECT_EQ(des_sdfg->containers().size(), 0);
+    EXPECT_EQ(des_sdfg->containers().size(), 1);
     EXPECT_EQ(des_sdfg->root().size(), 1);
 
     EXPECT_TRUE(sdfg::dyn_cast<sdfg::structured_control_flow::Map*>(&des_sdfg->root().at(0)) != nullptr);
@@ -1818,6 +1826,9 @@ TEST(JSONSerializerTest, SerializeDeserialize_Map) {
 TEST(JSONSerializerTest, SerializeDeserialize_Reduce) {
     sdfg::builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
     auto& root = builder.subject().root();
+
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
+    builder.add_container("i", sym_desc);
 
     auto& reduce = builder.add_reduce(
         root,
@@ -1836,11 +1847,12 @@ TEST(JSONSerializerTest, SerializeDeserialize_Reduce) {
     serializer.structured_loop_to_json(j, reduce);
 
     auto des_builder = sdfg::builder::StructuredSDFGBuilder("test_sdfg", FunctionType_CPU);
+    des_builder.add_container("i", sym_desc);
 
     serializer.json_to_structured_loop_node(j, des_builder, des_builder.subject().root());
     auto des_sdfg = des_builder.move();
     EXPECT_EQ(des_sdfg->name(), sdfg->name());
-    EXPECT_EQ(des_sdfg->containers().size(), 0);
+    EXPECT_EQ(des_sdfg->containers().size(), 1);
     EXPECT_EQ(des_sdfg->root().size(), 1);
 
     EXPECT_TRUE(sdfg::dyn_cast<sdfg::structured_control_flow::Reduce*>(&des_sdfg->root().at(0)) != nullptr);

--- a/sdfg/tests/structured_control_flow/loop_test.cpp
+++ b/sdfg/tests/structured_control_flow/loop_test.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
 #include "sdfg/builder/structured_sdfg_builder.h"
+#include "sdfg/codegen/dispatchers/for_dispatcher.h"
+#include "sdfg/codegen/language_extensions/cpp_language_extension.h"
 #include "sdfg/structured_control_flow/for.h"
 #include "sdfg/structured_control_flow/map.h"
 #include "sdfg/structured_control_flow/reduce.h"
@@ -1450,6 +1452,39 @@ TEST(StructuredLoopTest, IsLoopNormalFormFalseNoCanonicalBound) {
     );
 
     EXPECT_FALSE(loop.is_loop_normal_form());
+}
+
+TEST(StructuredLoopTest, AllowsPtrAsIndvar) {
+    builder::StructuredSDFGBuilder builder("test_sdfg", FunctionType_CPU);
+    types::Pointer ptr_type;
+    builder.add_container("head", ptr_type, true);
+    builder.add_container("end", ptr_type, true);
+    builder.add_container("it", ptr_type);
+
+    auto& for_node = builder.add_for(
+        builder.subject().root(),
+        symbolic::symbol("it"),
+        symbolic::Ne(symbolic::symbol("it"), symbolic::symbol("end")),
+        symbolic::symbol("head"),
+        symbolic::add(symbolic::symbol("it"), symbolic::one())
+    );
+
+    builder.subject().validate();
+
+    analysis::AnalysisManager ana(builder.subject());
+
+    auto ip = codegen::InstrumentationPlan::none(builder.subject());
+    auto ap = codegen::ArgCapturePlan::none(builder.subject());
+    codegen::CPPLanguageExtension lang(builder.subject());
+
+    codegen::ForDispatcher for_disp(lang, builder.subject(), ana, for_node, *ip, *ap);
+
+    codegen::PrettyPrinter p_main;
+    codegen::PrettyPrinter p_glob;
+    codegen::CodeSnippetFactory cs;
+    EXPECT_NO_THROW(for_disp.dispatch_node(p_main, p_glob, cs));
+    auto str = p_main.str();
+    EXPECT_TRUE(!str.empty());
 }
 
 } // namespace sdfg::structured_control_flow

--- a/sdfg/tests/visualizer/dot_visualizer_test.cpp
+++ b/sdfg/tests/visualizer/dot_visualizer_test.cpp
@@ -37,7 +37,7 @@ TEST(DotVisualizerTest, transpose) {
     auto& root = sdfg.root();
 
     // Add containers
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("M", sym_desc, true);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
@@ -126,7 +126,7 @@ TEST(DotVisualizerTest, transpose) {
 TEST(DotVisualizerTest, syrk) {
     builder::StructuredSDFGBuilder sdfg("sdfg_1", FunctionType_CPU);
 
-    types::Scalar desc_symbols(types::PrimitiveType::UInt64);
+    types::Scalar desc_symbols(types::PrimitiveType::Int64);
     sdfg.add_container("M", desc_symbols, true);
     sdfg.add_container("N", desc_symbols, true);
     sdfg.add_container("i", desc_symbols);
@@ -848,7 +848,7 @@ TEST(DotVisualizerTest, reduce) {
     auto& sdfg = builder.subject();
     auto& root = sdfg.root();
 
-    types::Scalar sym_desc(types::PrimitiveType::UInt64);
+    types::Scalar sym_desc(types::PrimitiveType::Int64);
     builder.add_container("N", sym_desc, true);
     builder.add_container("i", sym_desc);
 


### PR DESCRIPTION
More broadly replace hardcoded Int64 and UInt64 indvars with a function inferring the type from the expression (although for now, it only uses Int32 if it can prove that the immediate result fits into it, otherwise Int64).

Noticed that many places use UInt64, which is not technically valid and potentially problematic. Now enforcing no unsigned indvars on StructuredLoop validator and fixing test cases